### PR TITLE
Bugfixes

### DIFF
--- a/phys2bids/physio_obj.py
+++ b/phys2bids/physio_obj.py
@@ -394,7 +394,7 @@ class BlueprintOutput():
             In all the property that are lists, the element correspondent to
             `idx` gets deleted
         """
-        del(self.timeseries[idx])
+        self.timeseries = np.delete(self.timeseries, idx, axis=0)
         del(self.ch_name[idx])
         del(self.units[idx])
 

--- a/phys2bids/utils.py
+++ b/phys2bids/utils.py
@@ -23,15 +23,13 @@ def check_input_ext(filename, ext):
     """
     Checks that the given file has the given extension
     """
-    if '.gz' in ext:
-        if filename[-len(ext):] != ext:
-            filename = filename + ext
-        return filename
-    else:
-        if ext[0] != '.':
-            ext = '.' + ext
+    if '.gz' in filename:
+        filename = filename[:-3]
 
-        return Path(filename).with_suffix(ext)
+    if ext[0] != '.':
+        ext = '.' + ext
+
+    return Path(filename).with_suffix(ext)
 
 
 def check_input_type(filename, indir):

--- a/phys2bids/utils.py
+++ b/phys2bids/utils.py
@@ -13,7 +13,7 @@ def check_input_dir(indir):
     """
     Checks that the given indir doesn't have a trailing '/'
     """
-    if indir[-1:] == '/':
+    if indir.endswith('/'):
         indir = indir[:-1]
 
     return indir
@@ -23,10 +23,10 @@ def check_input_ext(filename, ext):
     """
     Checks that the given file has the given extension
     """
-    if '.gz' in filename:
+    if filename.endswith('.gz'):
         filename = filename[:-3]
 
-    if ext[0] != '.':
+    if not ext.startswith('.'):
         ext = '.' + ext
 
     return Path(filename).with_suffix(ext)


### PR DESCRIPTION
Fixes #77 and fixes #78 

Corrected method `delete_at_index` in `BlueprintOutput` to deal with numpy arrays
Corrected function in `utils.py` `check_input_ext`, now it can correctly handle `.gz` and `.ext.gz` extensions.

Is there any other possible double extension we should be able to check?