### PR TITLE
[DOC] Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Donwload the package as zip from github and uncompress or if you have ``git`` us
 
 open a terminal in the phy2bids folder and execute the command:
 
-``sudo pip3 install -e .``
+``pip3 install .``
 
 type the command:
 


### PR DESCRIPTION
Relates to #74.

Removes recommendation for using `sudo` and `-e` during package installation. I'm open to discussion on the option of the `-e` flag, but feel very strongly about **not** recommending the `sudo`.