### PR TITLE
Create only time channel from trigger channel, don't move around trigger

### DIFF
--- a/phys2bids/interfaces/acq.py
+++ b/phys2bids/interfaces/acq.py
@@ -35,17 +35,16 @@ def populate_phys_input(filename, chtrig):
 
     data = read_file(filename).channels
 
-    freq = [data[chtrig].samples_per_second] * 2
-    timeseries = [data[chtrig].time_index, data[chtrig].data]
-    units = ['s', data[chtrig].units]
-    names = ['time', 'trigger']
+    freq = [data[chtrig].samples_per_second, ]
+    timeseries = [data[chtrig].time_index, ]
+    units = ['s', ]
+    names = ['time', ]
 
     for k, ch in enumerate(data):
-        if k != chtrig:
-            LGR.info(f'{k:02d}. {ch}')
-            timeseries.append(ch.data)
-            freq.append(ch.samples_per_second)
-            units.append(ch.units)
-            names.append(ch.name)
+        LGR.info(f'{k:02d}. {ch}')
+        timeseries.append(ch.data)
+        freq.append(ch.samples_per_second)
+        units.append(ch.units)
+        names.append(ch.name)
 
     return BlueprintInput(timeseries, freq, names, units)

--- a/phys2bids/phys2bids.py
+++ b/phys2bids/phys2bids.py
@@ -192,6 +192,11 @@ def _main(argv=None):
     """
     options = _get_parser().parse_args(argv)
 
+    # Check options to make them internally coherent pt. I
+    # #!# This can probably be done while parsing?
+    options.outdir = utils.check_input_dir(options.outdir)
+    utils.path_exists_or_make_it(options.outdir)
+
     # Create logfile name
     basename = 'phys2bids_'
     extension = 'tsv'
@@ -222,10 +227,9 @@ def _main(argv=None):
     LGR.info(f'Currently running phys2bids version {version_number}')
     LGR.info(f'Input file is {options.filename}')
 
-    # Check options to make them internally coherent
+    # Check options to make them internally coherent pt. II
     # #!# This can probably be done while parsing?
     options.indir = utils.check_input_dir(options.indir)
-    options.outdir = utils.check_input_dir(options.outdir)
     options.filename, ftype = utils.check_input_type(options.filename,
                                                      options.indir)
 
@@ -262,10 +266,6 @@ def _main(argv=None):
     # #!# Get option of no trigger! (which is wrong practice or Respiract)
     phys_in.check_trigger_amount(options.thr, options.num_timepoints_expected,
                                  options.tr)
-
-    # Create output folder if necessary
-    LGR.info('Checking that the output folder exists')
-    utils.path_exists_or_make_it(options.outdir)
 
     # Create trigger plot. If possible, to have multiple outputs in the same
     # place, adds sub and ses label.


### PR DESCRIPTION
Closes #

To be reviewed after #154 

## Proposed Changes

  - Now interfaces.acq.py reads the file without moving around the supposed trigger channel. It only creates the time from it.