### PR TITLE
Improve code compliance to BIDS in BlueprintOputput

### DIFF
--- a/phys2bids/phys2bids.py
+++ b/phys2bids/phys2bids.py
@@ -348,7 +348,7 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
                 outfile = f'{outfile}_{uniq_freq}'
 
         LGR.info(f'Exporting files for freq {uniq_freq}')
-        savetxt(outfile + '.tsv.gz', phys_out[uniq_freq].timeseries.T,
+        savetxt(outfile + '.tsv.gz', phys_out[uniq_freq].timeseries,
                 fmt='%.8e', delimiter='\t')
         print_json(outfile, phys_out[uniq_freq].freq,
                    phys_out[uniq_freq].start_time,

--- a/phys2bids/physio_obj.py
+++ b/phys2bids/physio_obj.py
@@ -379,7 +379,7 @@ class BlueprintOutput():
         int
             Number of channels
         """
-        return len(self.timeseries)
+        return self.timeseries.shape[1]
 
     def return_index(self, idx):
         """
@@ -397,7 +397,7 @@ class BlueprintOutput():
             Tuple containing the proper list entry of all the
             properties of the object with index `idx`
         """
-        return (self.timeseries[idx], self.ch_amount, self.freq,
+        return (self.timeseries[:, idx], self.ch_amount, self.freq,
                 self.ch_name[idx], self.units[idx], self.start_time)
 
     def delete_at_index(self, idx):
@@ -423,7 +423,7 @@ class BlueprintOutput():
             In all the property that are lists, the element correspondent to
             `idx` gets deleted
         """
-        self.timeseries = np.delete(self.timeseries, idx, axis=0)
+        self.timeseries = np.delete(self.timeseries, idx, axis=1)
         del self.ch_name[idx]
         del self.units[idx]
 
@@ -445,7 +445,7 @@ class BlueprintOutput():
         cls: :obj: `BlueprintOutput`
             Populated `BlueprintOutput` object.
         """
-        timeseries = np.asarray(blueprint.timeseries)
+        timeseries = np.asarray(blueprint.timeseries).T
         freq = blueprint.freq[0]
         ch_name = blueprint.ch_name
         units = blueprint.units

--- a/phys2bids/tests/test_physio_obj.py
+++ b/phys2bids/tests/test_physio_obj.py
@@ -93,7 +93,7 @@ def test_BlueprintOutput():
     # Tests init_from_blueprint
     blueprint_out = po.BlueprintOutput.init_from_blueprint(blueprint_in)
     start_time = blueprint_out.start_time
-    assert (blueprint_out.timeseries == test_timeseries).all()
+    assert (blueprint_out.timeseries == np.asarray(test_timeseries).T).all()
     assert blueprint_out.freq == test_freq[0]
     assert blueprint_out.ch_name == test_chn_name
     assert blueprint_out.units == test_units
@@ -102,16 +102,16 @@ def test_BlueprintOutput():
     # Tests return_index
     test_timeseries = np.array([[0, 1, 1, 2, 3, 5, 8, 13],
                                 [0, 1, 0, 0, 0, 0, 0, 0],
-                                [1, 0, 0, 1, 0, 0, 1, 0]])
+                                [1, 0, 0, 1, 0, 0, 1, 0]]).T
     test_freq = 42.0
     test_chn_name = ['trigger', 'time', 'chocolate']
     test_units = ['s', 's', 'sweetness']
-    num_channnels = len(test_timeseries)
+    num_channnels = test_timeseries.shape[1]
     blueprint_out = po.BlueprintOutput(test_timeseries, test_freq, test_chn_name, test_units,
                                        start_time)
     test_index = blueprint_out.return_index(1)
     assert (test_index[0] == test_trigger).all()
-    assert test_index[1] == len(test_timeseries)
+    assert test_index[1] == test_timeseries.shape[1]
     assert test_index[3] == test_chn_name[1]
     assert test_index[4] == test_units[1]
 
@@ -119,5 +119,5 @@ def test_BlueprintOutput():
     blueprint_out.delete_at_index(1)
     assert len(blueprint_out.ch_name) == num_channnels - 1
     assert len(blueprint_out.units) == num_channnels - 1
-    assert blueprint_out.timeseries.shape[0] == num_channnels - 1
+    assert blueprint_out.timeseries.shape[1] == num_channnels - 1
     assert blueprint_out.ch_amount == num_channnels - 1


### PR DESCRIPTION
Closes #184 better than #187 

## Proposed Changes

  - Instead of a final transposition of the `timeseries` attribute of the `BlueprintOuput` during export, the object is initialised BIDS compliant.