### PR TITLE
Print float to max 4 decimal places

### DIFF
--- a/phys2bids/phys2bids.py
+++ b/phys2bids/phys2bids.py
@@ -76,7 +76,7 @@ def print_summary(filename, ntp_expected, ntp_found, samp_freq, time_offset, out
                f'Timepoints expected: {ntp_expected}\n'
                f'Timepoints found:    {ntp_found}\n'
                f'Sampling Frequency:  {samp_freq} Hz\n'
-               f'Sampling started at: {start_time} s\n'
+               f'Sampling started at: {start_time:.4f} s\n'
                f'Tip: Time 0 is the time of first trigger\n'
                f'------------------------------------------------\n')
     LGR.info(summary)
@@ -106,7 +106,7 @@ def print_json(outfile, samp_freq, time_offset, ch_name):
     """
     start_time = -time_offset
     summary = dict(SamplingFrequency=samp_freq,
-                   StartTime=start_time,
+                   StartTime=round(start_time, 4),
                    Columns=ch_name)
     utils.writejson(outfile, summary, indent=4, sort_keys=False)
 

--- a/phys2bids/physio_obj.py
+++ b/phys2bids/physio_obj.py
@@ -459,9 +459,9 @@ class BlueprintInput():
                                     lambda x: x != 0) if is_true])
         if flag == 1:
             LGR.info(f'The number of timepoints according to the std_thr method '
-                     f'is {num_timepoints_found}. The computed threshold is {thr}')
+                     f'is {num_timepoints_found}. The computed threshold is {thr:.4f}')
         else:
-            LGR.info(f'The number of timepoints found with the manual threshold of {thr} '
+            LGR.info(f'The number of timepoints found with the manual threshold of {thr:.4f} '
                      f'is {num_timepoints_found}')
         time_offset = self.timeseries[0][timepoints.argmax()]
 

--- a/phys2bids/tests/test_integration.py
+++ b/phys2bids/tests/test_integration.py
@@ -82,7 +82,7 @@ def test_integration_tutorial():
     # Check sampling frequency
     assert check_string(log_info, 'Sampling Frequency', '1000.0')
     # Check sampling frequency
-    assert check_string(log_info, 'Sampling started', '0.24499999999989086')
+    assert check_string(log_info, 'Sampling started', '0.2450')
     # Check start time
     assert check_string(log_info, 'first trigger', 'Time 0', is_num=False)
 
@@ -92,7 +92,7 @@ def test_integration_tutorial():
 
     # Compares values in json file with ground truth
     assert math.isclose(json_data['SamplingFrequency'], 1000.0)
-    assert math.isclose(json_data['StartTime'], 0.245)
+    assert math.isclose(json_data['StartTime'], 0.2450)
     assert json_data['Columns'] == ['time', 'Trigger', 'CO2', 'O2', 'Pulse']
 
     # Remove generated files
@@ -126,7 +126,7 @@ def test_integration_acq(samefreq_full_acq_file):
     # Check sampling frequency
     assert check_string(log_info, 'Sampling Frequency', '10000.0')
     # Check sampling started
-    assert check_string(log_info, 'Sampling started', '10.425107798467103')
+    assert check_string(log_info, 'Sampling started', '10.4251')
     # Check start time
     assert check_string(log_info, 'first trigger', 'Time 0', is_num=False)
 
@@ -136,7 +136,7 @@ def test_integration_acq(samefreq_full_acq_file):
 
     # Compares values in json file with ground truth
     assert math.isclose(json_data['SamplingFrequency'], 10000.0)
-    assert math.isclose(json_data['StartTime'], 10.425107798467103)
+    assert math.isclose(json_data['StartTime'], 10.4251)
     assert json_data['Columns'] == ['time', 'RESP - RSP100C', 'PULSE - Custom, DA100C',
                                     'MR TRIGGER - Custom, HLT100C - A 5', 'PPG100C', 'CO2', 'O2']
 
@@ -181,7 +181,7 @@ def test_integration_multifreq(multifreq_acq_file):
     # Check sampling frequency
     assert check_string(log_info, 'Sampling Frequency', '625.0')
     # Check sampling frequency
-    assert check_string(log_info, 'Sampling started', '0.29052734375')
+    assert check_string(log_info, 'Sampling started', '0.2905')
     # Check start time
     assert check_string(log_info, 'first trigger', 'Time 0', is_num=False)
 
@@ -191,7 +191,7 @@ def test_integration_multifreq(multifreq_acq_file):
 
     # Compares values in json file with ground truth
     assert math.isclose(json_data['SamplingFrequency'], 625.0)
-    assert math.isclose(json_data['StartTime'], 0.29052734375)
+    assert math.isclose(json_data['StartTime'], 0.2905)
     assert json_data['Columns'] == ['PULSE - Custom, DA100C']
 
     """
@@ -208,7 +208,7 @@ def test_integration_multifreq(multifreq_acq_file):
     # Check sampling frequency
     assert check_string(log_info, 'Sampling Frequency', '10000.0')
     # Check sampling started
-    assert check_string(log_info, 'Sampling started', '10.425107798467103')
+    assert check_string(log_info, 'Sampling started', '10.4251')
     # Check start time
     assert check_string(log_info, 'first trigger', 'Time 0', is_num=False)
 
@@ -218,7 +218,7 @@ def test_integration_multifreq(multifreq_acq_file):
 
     # Compares values in json file with ground truth
     assert math.isclose(json_data['SamplingFrequency'], 10000.0)
-    assert math.isclose(json_data['StartTime'], 10.425107798467103)
+    assert math.isclose(json_data['StartTime'], 10.4251)
     assert json_data['Columns'] == ['time', 'RESP - RSP100C',
                                     'MR TRIGGER - Custom, HLT100C - A 5', 'PPG100C', 'CO2', 'O2']
 
@@ -266,7 +266,7 @@ def test_integration_heuristic():
     # Check sampling frequency
     assert check_string(log_info, 'Sampling Frequency', '1000.0')
     # Check sampling started
-    assert check_string(log_info, 'Sampling started', '0.24499999999989086')
+    assert check_string(log_info, 'Sampling started', '0.2450')
     # Check start time
     assert check_string(log_info, 'first trigger', 'Time 0', is_num=False)
 
@@ -277,7 +277,7 @@ def test_integration_heuristic():
 
     # Compares values in json file with ground truth
     assert math.isclose(json_data['SamplingFrequency'], 1000.0)
-    assert math.isclose(json_data['StartTime'], 0.24499999999989086)
+    assert math.isclose(json_data['StartTime'], 0.2450)
     assert json_data['Columns'] == ['time', 'Trigger', 'CO2', 'O2', 'Pulse']
 
     # Remove generated files


### PR DESCRIPTION
Closes #26 

## Proposed Changes

  - Any print of a float should have max 4 decimals. 

# Progress/Questions 

-  Currently, I added some code to print out _start_time_ with 4 decimals places in both the log and the json file. This was just something I quickly tried - Is this the kind of thing we want? Or will I need to make this more generalised and make a function that defines how any float is printed? 
- I am not sure how I approach writing the unit test. 




