### PR TITLE
Fix azure pipelines non-failure bug

### DIFF
--- a/.azure-pipelines/windows.yml
+++ b/.azure-pipelines/windows.yml
@@ -36,13 +36,11 @@ jobs:
         mkdir for_testing
         cd for_testing
         cp ../setup.cfg .
-        python -m pytest --doctest-modules --cov-report term-missing --cov=phys2bids --pyargs phys2bids
-        cp ./.coverage ../
+        python -m pytest --doctest-modules --cov-report term-missing --cov-report xml --cov=phys2bids --pyargs phys2bids
       displayName: 'Run tests'
-      condition: and(succeeded(), eq(variables['CHECK_TYPE'], 'test'))
-    - script: |
-        python -m pip install codecov
-        codecov
+      failOnStderr: true
+    - bash: |
+        bash <(curl -s https://codecov.io/bash) -Z -C $BUILD_SOURCEVERSION
       displayName: 'Upload To Codecov'
       env:
         CODECOV_TOKEN: $(CODECOV_TOKEN)

--- a/.azure-pipelines/windows.yml
+++ b/.azure-pipelines/windows.yml
@@ -42,5 +42,3 @@ jobs:
     - bash: |
         bash <(curl -s https://codecov.io/bash) -Z -C $BUILD_SOURCEVERSION
       displayName: 'Upload To Codecov'
-      env:
-        CODECOV_TOKEN: $(CODECOV_TOKEN)


### PR DESCRIPTION
Closes #215 

## Proposed Changes

- Adds `failOnStderr` entry to YAML for running the tests to, hopefully, fail when there are errors

Not sure if this will _actually_ fix things given that they seem to magically be working again, but will see how things go with this PR. May purposefully break something to see if I can reproduce the errors we were seeing before, but will let this run through once, first!