### PR TITLE
Enh/bids units

### DIFF
--- a/phys2bids/bids_units.py
+++ b/phys2bids/bids_units.py
@@ -4,25 +4,27 @@ LGR = logging.getLogger(__name__)
 
 unit_aliases = {
                 # kelvin: thermodynamic temperature
-                'k': 'K', 'kelvin': 'K', 'kelvins': 'K',
+                'kelvin': 'K', 'kelvins': 'K',
                 # mole: amount of substance
                 'mol': 'mol', 'mole': 'mol',
                 # newton: force, weight
-                'newton': 'N', 'newtons': 'N', 'n': 'N',
+                'newton': 'N', 'newtons': 'N',
                 # pascal: pressure, stress
                 'pascal': 'Pa', 'pascals': 'Pa', 'pa': 'Pa',
                 # volt: voltage (electrical potential), emf
-                'v': 'V', 'volt': 'V', 'volts': 'V',
+                'volt': 'V', 'volts': 'V',
                 # degree Celsius: temperature relative to 273.15 K
                 '°c': '°C', '°celsius': '°C', 'celsius': '°C',
                 # ampere: electric current
-                'a': 'A', 'ampere': 'A', 'amp': 'A', 'amps': 'A',
-                # second: time and hertzs
+                'ampere': 'A', 'amp': 'A', 'amps': 'A',
+                # second: time and hertzs: frequency
                 '1/hz': 's', '1/hertz': 's', 'hz': 'Hz',
                 '1/s': 'Hz', '1/second': 'Hz', '1/seconds': 'Hz',
                 '1/sec': 'Hz', '1/secs': 'Hz', 'hertz': 'Hz',
                 'second': 's', 'seconds': 's', 'sec': 's',
-                'secs': 's', 's': 's',
+                'secs': 's',
+                # All the aliases with one letter (to avoid issues)
+                'k': 'K',  'n': 'N', 'v': 'V', 'c': '°C', 'a': 'A', 's': 's',
 }
 
 # Init dictionary of aliases for multipliers. Entries are still lowercase
@@ -73,8 +75,8 @@ def bidsify_units(orig_unit):
                 # for every prefix alias
                 prefix = prefix_aliases.get(unit, '')
                 if prefix == '':
-                    LGR.warning(f'The given unit prefix {unit} does not have aliases, '
-                                f'passing it as is')
+                    LGR.warning(f'The given unit prefix {unit} does not '
+                                'have aliases, passing it as is')
                     prefix = orig_unit[:len(unit)]
 
                 return prefix + new_unit

--- a/phys2bids/bids_units.py
+++ b/phys2bids/bids_units.py
@@ -24,7 +24,7 @@ UNIT_ALIASES = {
                 'second': 's', 'seconds': 's', 'sec': 's',
                 'secs': 's',
                 # All the aliases with one letter (to avoid issues)
-                'k': 'K',  'n': 'N', 'v': 'V', 'c': '°C', 'a': 'A', 's': 's',
+                'k': 'K', 'n': 'N', 'v': 'V', 'c': '°C', 'a': 'A', 's': 's',
 }
 
 # Init dictionary of aliases for multipliers. Entries are still lowercase

--- a/phys2bids/bids_units.py
+++ b/phys2bids/bids_units.py
@@ -2,7 +2,7 @@ import logging
 
 LGR = logging.getLogger(__name__)
 
-unit_aliases = {
+UNIT_ALIASES = {
                 # kelvin: thermodynamic temperature
                 'kelvin': 'K', 'kelvins': 'K',
                 # mole: amount of substance
@@ -28,7 +28,7 @@ unit_aliases = {
 }
 
 # Init dictionary of aliases for multipliers. Entries are still lowercase
-prefix_aliases = {
+PREFIX_ALIASES = {
                     # Multiples - skip "mega" and only up to "tera"
                     'da': 'da', 'deca': 'da', 'h': 'h', 'hecto': 'h',
                     'k': 'k', 'kilo': 'k', 'g': 'G', 'giga': 'G', 't': 'T',
@@ -66,14 +66,14 @@ def bidsify_units(orig_unit):
     """
     # for every unit alias in the dict
     unit = orig_unit.lower()
-    for u_key in unit_aliases.keys():
+    for u_key in UNIT_ALIASES.keys():
         # check that u_key is part of unit
         if unit.endswith(u_key):
-            new_unit = unit_aliases[u_key]
+            new_unit = UNIT_ALIASES[u_key]
             unit = unit[:-len(u_key)]
             if unit != '':
                 # for every prefix alias
-                prefix = prefix_aliases.get(unit, '')
+                prefix = PREFIX_ALIASES.get(unit, '')
                 if prefix == '':
                     LGR.warning(f'The given unit prefix {unit} does not '
                                 'have aliases, passing it as is')

--- a/phys2bids/bids_units.py
+++ b/phys2bids/bids_units.py
@@ -44,7 +44,7 @@ def bidsify_units(orig_unit):
     """
     Read the input unit of measure and use the dictionary of aliases
     to bidsify its value.
-    It is possible to make simple conversions
+    It is possible to make simple conversions.
 
     Parameters
     ----------
@@ -62,13 +62,13 @@ def bidsify_units(orig_unit):
     the other for prefixes (e.g. "milli"). However, that is going to be tricky,
     unless there is a weird way to multiply two dictionaries together.
     """
-    # call prefix and unit dicts
     # for every unit alias in the dict
-    orig_unit = orig_unit.lower()
+    unit = orig_unit.lower()
     for u_key in unit_aliases.keys():
-        if orig_unit.endswith(u_key):
+        # check that u_key is part of unit
+        if unit.endswith(u_key):
             new_unit = unit_aliases[u_key]
-            unit = orig_unit[:-len(u_key)]
+            unit = unit[:-len(u_key)]
             if unit != '':
                 # for every prefix alias
                 prefix = prefix_aliases.get(unit, '')
@@ -76,9 +76,12 @@ def bidsify_units(orig_unit):
                     LGR.warning(f'The given unit prefix {unit} does not have aliases, '
                                 f'passing it as is')
                     prefix = orig_unit[:len(unit)]
+
                 return prefix + new_unit
             else:
                 return new_unit
+
+    # If we conclude the loop without returning, it means the unit doesn't have aliases
     LGR.warning(f'The given unit {orig_unit} does not have aliases, '
                 f'passing it as is')
     return orig_unit

--- a/phys2bids/tests/test_bids_units.py
+++ b/phys2bids/tests/test_bids_units.py
@@ -1,5 +1,5 @@
 from phys2bids.bids_units import bidsify_units
-from phys2bids.bids_units import unit_aliases
+from phys2bids.bids_units import UNIT_ALIASES
 
 
 def test_bidsify_units():
@@ -16,5 +16,5 @@ def test_bidsify_units():
     for unit_key in unit_tests.keys():
         assert bidsify_units(unit_key) == unit_tests[unit_key]
     # test there is not problem with every unit in the dict
-    for unit_key in unit_aliases.keys():
-        assert bidsify_units(unit_key) == unit_aliases[unit_key]
+    for unit_key in UNIT_ALIASES.keys():
+        assert bidsify_units(unit_key) == UNIT_ALIASES[unit_key]

--- a/phys2bids/tests/test_bids_units.py
+++ b/phys2bids/tests/test_bids_units.py
@@ -3,12 +3,18 @@ from phys2bids.bids_units import unit_aliases
 
 
 def test_bidsify_units():
-    # test unit with standard prefix
-    assert bidsify_units('centik') == 'cK'
-    # test unit with not standard prefix
-    assert bidsify_units('matV') == 'matV'
-    # test unit that's not bids standard
-    assert bidsify_units('mmlie') == 'mmlie'
+    # Add a dictionary of test possibilities
+    unit_tests = {
+                  # test unit with standard prefix
+                  'centik': 'cK', 'CENTIk': 'cK',
+                  # test unit with not standard prefix
+                  'matV': 'matV', 'BigV': 'BigV',
+                  # test unit that are not bids standard
+                  'mmHg': 'mmHg', 'mmlie': 'mmlie', 'MMLIE': 'MMLIE',
+                 }
+    # Actually test
+    for unit_key in unit_tests.keys():
+        assert bidsify_units(unit_key) == unit_tests[unit_key]
     # test there is not problem with every unit in the dict
     for unit_key in unit_aliases.keys():
         assert bidsify_units(unit_key) == unit_aliases[unit_key]


### PR DESCRIPTION
Closes nothing, but follows #222 .

The code in master is nice, but there are cases that might not be handled.
For instance, if `'mmHg'` (Which is a non-BIDS unit we might end up having, since it's the standard unit for some gas applications e.g. CVR) is passed as an argument to `bidsify_units`, it would return `mmhg`. The same can be said for `BigV` or `MMLIE` (examples adapted from the test). It's not a huge deal, but if it's not a SI unit, at least we should leave it as it is without changing it.
There's still cases that are not supported (e.g. non-SI term `plethora` would return 'plethorA'), but that's for another day (and I hope no one would measure "0.56 plethora of physiological activity" in the meantime).  

## Proposed Changes

  - Little code refactoring to support more cases
  - Add more testing cases, also reorganise weird aliases tests as a dictionary similarly to the current real unit test.
  - Quick dictionary reordering to lower the possibility of clashes
  - Uppercase all the constants