### PR TITLE
Add duecredit to handle citations

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,8 @@ If you use ``phys2bids``, please cite it using the Zenodo DOI as:
 
     The phys2bids contributors, Daniel Alcalá, Apoorva Ayyagari, Molly Bright, César Caballero-Gaudes, Vicente Ferrer Gallardo, Soichi Hayashi, Ross Markello, Stefano Moia, Rachael Stickland, Eneko Uruñuela, & Kristina Zvolanek (2020, February 6). physiopy/phys2bids: BIDS formatting of physiological recordings v1.3.0-beta (Version v1.3.0-beta). Zenodo. http://doi.org/10.5281/zenodo.3653153
 
+We also support gathering all relevant citations via `DueCredit <http://duecredit.org>`_.
+
 
 Contents
 --------

--- a/phys2bids/due.py
+++ b/phys2bids/due.py
@@ -1,0 +1,69 @@
+# emacs: at the end of the file
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### #
+"""
+Stub file for a guaranteed safe import of duecredit constructs:  if duecredit
+is not available.
+To use it, place it into your project codebase to be imported, e.g. copy as
+    cp stub.py /path/tomodule/module/due.py
+Note that it might be better to avoid naming it duecredit.py to avoid shadowing
+installed duecredit.
+Then use in your code as
+    from .due import due, Doi, BibTeX
+See  https://github.com/duecredit/duecredit/blob/master/README.md for examples.
+Origin:     Originally a part of the duecredit
+Copyright:  2015-2016  DueCredit developers
+License:    BSD-2
+"""
+
+from builtins import str
+from builtins import object
+__version__ = '0.0.5'
+
+
+class InactiveDueCreditCollector(object):
+    """Just a stub at the Collector which would not do anything"""
+    def _donothing(self, *args, **kwargs):
+        """Perform no good and no bad"""
+        pass
+
+    def dcite(self, *args, **kwargs):
+        """If I could cite I would"""
+        def nondecorating_decorator(func):
+            return func
+        return nondecorating_decorator
+
+    cite = load = add = _donothing
+
+    def __repr__(self):
+        return self.__class__.__name__ + '()'
+
+
+def _donothing_func(*args, **kwargs):
+    """Perform no good and no bad"""
+    pass
+
+
+try:
+    from duecredit import due, BibTeX, Doi, Url
+    if 'due' in locals() and not hasattr(due, 'cite'):
+        raise RuntimeError(
+            "Imported due lacks .cite. DueCredit is now disabled")
+except Exception as e:
+    if type(e).__name__ != 'ImportError':
+        import logging
+        logging.getLogger("duecredit").error(
+            'Module `duecredit` not successfully imported due to "%s". '
+            'Package functionality unaffected.', str(e))
+
+    # Initiate due stub
+    due = InactiveDueCreditCollector()
+    BibTeX = Doi = Url = _donothing_func
+
+# Emacs mode definitions
+# Local Variables:
+# mode: python
+# py-indent-offset: 4
+# tab-width: 4
+# indent-tabs-mode: nil
+# End:

--- a/phys2bids/phys2bids.py
+++ b/phys2bids/phys2bids.py
@@ -120,7 +120,7 @@ def print_json(outfile, samp_freq, time_offset, ch_name):
      version=__version__,
      cite_module=True)
 @due.dcite(
-    DOI('10.1038/sdata.2016.44'),
+    Doi('10.1038/sdata.2016.44'),
     path='phys2bids',
     description='The BIDS specification',
     cite_module=True)

--- a/phys2bids/phys2bids.py
+++ b/phys2bids/phys2bids.py
@@ -38,6 +38,9 @@ from phys2bids.bids import bidsify_units, use_heuristic
 from phys2bids.cli.run import _get_parser
 from phys2bids.physio_obj import BlueprintOutput
 
+from . import __version__
+from .due import due, Doi
+
 LGR = logging.getLogger(__name__)
 
 
@@ -110,6 +113,17 @@ def print_json(outfile, samp_freq, time_offset, ch_name):
     utils.writejson(outfile, summary, indent=4, sort_keys=False)
 
 
+@due.dcite(
+     Doi('10.5281/zenodo.3470091'),
+     path='phys2bids',
+     description='Conversion of physiological trace data to BIDS format',
+     version=__version__,
+     cite_module=True)
+@due.dcite(
+    DOI('10.1038/sdata.2016.44'),
+    path='phys2bids',
+    description='The BIDS specification',
+    cite_module=True)
 def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
               sub=None, ses=None, chtrig=0, chsel=None, num_timepoints_expected=0,
               tr=1, thr=None, ch_name=[], chplot='', debug=False, quiet=False):
@@ -119,7 +133,7 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
     Runs the parser, does some checks on input, then imports
     the right interface file to read the input. If only info is required,
     it returns a summary onscreen.
-    Otherwise, it operates on the input to return a .tsv.gz file, possibily
+    Otherwise, it operates on the input to return a .tsv.gz file, possibly
     in BIDS format.
 
     Raises

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,8 +32,10 @@ packages = find:
 include_package_data = True
 
 [options.extras_require]
-acq = 
+acq =
     bioread >=1.0.5
+duecredit =
+    duecredit
 doc =
     sphinx >=2.0
     sphinx-argparse
@@ -44,10 +46,11 @@ style =
 test =
     pytest >=5.3
     pytest-cov
-interfaces = 
+interfaces =
     %(acq)s
 all =
     %(interfaces)s
+    %(duecredit)s
     %(doc)s
     %(style)s
     %(test)s


### PR DESCRIPTION
Closes #248.

## Proposed Changes

  - Add `duecredit` as an optional dependency.
  - Add `duecredit` stub file, which is necessary to prevent errors when duecredit is not installed.
  - Add citations for phys2bids Zenodo and BIDS paper as decorators to main workflow.