### PR TITLE
Correct trigger channel indexing while reading AcqKnowledge files.

### DIFF
--- a/phys2bids/cli/run.py
+++ b/phys2bids/cli/run.py
@@ -76,9 +76,9 @@ def _get_parser():
                           dest='chtrig',
                           type=int,
                           help='The column number of the trigger channel. '
-                               'Channel numbering starts with 0. '
-                               'Default is 0.',
-                          default=0)
+                               'Channel numbering starts with 1. '
+                               'Default is 1.',
+                          default=1)
     optional.add_argument('-chsel', '--channel-selection',
                           dest='chsel',
                           nargs='*',

--- a/phys2bids/interfaces/acq.py
+++ b/phys2bids/interfaces/acq.py
@@ -30,9 +30,9 @@ def populate_phys_input(filename, chtrig):
 
     Note
     ----
-    chtrig is not a python index - instead, it's human readable.
-    This is handy because when initialising the class, it gets initiliased
-    with a channel more at the beginning - that is already taken into account!
+    chtrig is not a 0-based Python index - instead, it's human readable (i.e., 1-based).
+    This is handy because, when initialising the class, a new channel corresponding
+    to time is added at the beginning - that is already taken into account!
 
     See Also
     --------

--- a/phys2bids/interfaces/acq.py
+++ b/phys2bids/interfaces/acq.py
@@ -21,23 +21,29 @@ def populate_phys_input(filename, chtrig):
     filename: str
         path to the txt labchart file
     chtrig : int
-        index of trigger channel
+        index of trigger channel.
+        !!! ATTENTION: IT'S MEANT TO REPRESENT AN INDEX STARTING FROM 1 !!!
 
     Returns
     -------
     BlueprintInput
 
+    Note
+    ----
+    chtrig is not a python index - instead, it's human readable.
+    This is handy because when initialising the class, it gets initiliased
+    with a channel more at the beginning - that is already taken into account!
+
     See Also
     --------
     physio_obj.BlueprintInput
     """
-
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore', category=DeprecationWarning)
         data = read_file(filename).channels
 
-    freq = [data[chtrig].samples_per_second, ]
-    timeseries = [data[chtrig].time_index, ]
+    freq = [data[chtrig - 1].samples_per_second, ]
+    timeseries = [data[chtrig - 1].time_index, ]
     units = ['s', ]
     names = ['time', ]
 

--- a/phys2bids/interfaces/acq.py
+++ b/phys2bids/interfaces/acq.py
@@ -21,7 +21,7 @@ def populate_phys_input(filename, chtrig):
     filename: str
         path to the txt labchart file
     chtrig : int
-        index of trigger channel.
+        index of trigger channel. Must be a positive, non-zero integer.
         !!! ATTENTION: IT'S MEANT TO REPRESENT AN INDEX STARTING FROM 1 !!!
 
     Returns

--- a/phys2bids/interfaces/acq.py
+++ b/phys2bids/interfaces/acq.py
@@ -21,7 +21,7 @@ def populate_phys_input(filename, chtrig):
     filename: str
         path to the txt labchart file
     chtrig : int
-        index of trigger channel. Must be a positive, non-zero integer.
+        index of trigger channel.
         !!! ATTENTION: IT'S MEANT TO REPRESENT AN INDEX STARTING FROM 1 !!!
 
     Returns

--- a/phys2bids/phys2bids.py
+++ b/phys2bids/phys2bids.py
@@ -192,7 +192,7 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
     # #!# This can probably be done while parsing?
     indir = utils.check_input_dir(indir)
     if chtrig < 1:
-        raise Exception('Wrong trigger cahnnel. Channel indexing starts with 1!')
+        raise Exception('Wrong trigger channel. Channel indexing starts with 1!')
 
     filename, ftype = utils.check_input_type(filename,
                                              indir)

--- a/phys2bids/phys2bids.py
+++ b/phys2bids/phys2bids.py
@@ -127,7 +127,7 @@ def print_json(outfile, samp_freq, time_offset, ch_name):
     description='The BIDS specification',
     cite_module=True)
 def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
-              sub=None, ses=None, chtrig=0, chsel=None, num_timepoints_expected=None,
+              sub=None, ses=None, chtrig=1, chsel=None, num_timepoints_expected=None,
               tr=None, thr=None, pad=9, ch_name=[], yml='', debug=False, quiet=False):
     """
     Run main workflow of phys2bids.
@@ -191,6 +191,9 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
     # Check options to make them internally coherent pt. II
     # #!# This can probably be done while parsing?
     indir = utils.check_input_dir(indir)
+    if chtrig < 1:
+        raise Exception('Wrong trigger cahnnel. Channel indexing starts with 1!')
+
     filename, ftype = utils.check_input_type(filename,
                                              indir)
 


### PR DESCRIPTION
Closes #272, although the fixed problem is not the same - still, thanks @tsalo!

Turns out the algorithm was meant to extract the channel _after_ the one of the trigger since we modified phys2bids to have `-chtrig` human-friendly (rather than pythonic). 

## Proposed Changes

  - the `chtrig` index is lowered by one in place when extracting the timeseries from the trigger channel.
  - the docstring now indicate that chtrig is meant to represent an index starting from 1.