### PR TITLE
Add support for MATLAB files

### DIFF
--- a/phys2bids/interfaces/mat.py
+++ b/phys2bids/interfaces/mat.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""phys2bids interface for MATLAB files."""
+
+import logging
+
+import numpy as np
+from scipy.io import loadmat
+
+from phys2bids.physio_obj import BlueprintInput
+
+LGR = logging.getLogger(__name__)
+
+
+def populate_phys_input(filename, chtrig):
+    """
+    Populate object phys_input from MATLAB files.
+
+    Parameters
+    ----------
+    filename: str
+        path to the txt labchart file
+    chtrig : int
+        index of trigger channel.
+        !!! ATTENTION: IT'S MEANT TO REPRESENT AN INDEX STARTING FROM 1 !!!
+
+    Returns
+    -------
+    BlueprintInput
+
+    Note
+    ----
+    chtrig is not a 0-based Python index - instead, it's human readable (i.e., 1-based).
+    This is handy because, when initialising the class, a new channel corresponding
+    to time is added at the beginning - that is already taken into account!
+
+    See Also
+    --------
+    physio_obj.BlueprintInput
+    """
+
+    # Load MATLAB file into dictionary.
+    mat_dict = loadmat(filename)
+
+    # Convert data into 1d numpy array for easier indexing.
+    data = np.squeeze(np.asarray(mat_dict['data']))
+
+    # Extract number of channels.
+    n_channels = len(mat_dict['titles'])
+
+    # Stores MATLAB data into lists.
+    timeseries = [data[:int(mat_dict['dataend'][0])], ]
+    freq = [mat_dict['samplerate'][ch][0] for ch in range(n_channels)]
+    units = [mat_dict['unittext'][int(mat_dict['unittextmap'][ch][0] - 1)].strip() for ch in range(n_channels)]
+    names = [mat_dict['titles'][ch].strip() for ch in range(n_channels)]
+
+    # Appends data from channels > 1.
+    if n_channels > 1:
+        for ch in range(n_channels - 1):
+            idx_start = int(mat_dict['dataend'][ch]) + 1
+            idx_end = int(mat_dict['dataend'][ch+1])
+            timeseries.append(data[idx_start:idx_end])
+
+    return BlueprintInput(timeseries, freq, names, units, chtrig)

--- a/phys2bids/interfaces/mat.py
+++ b/phys2bids/interfaces/mat.py
@@ -39,14 +39,13 @@ def populate_phys_input(filename, chtrig):
     --------
     physio_obj.BlueprintInput
     """
-
     # Load MATLAB file into dictionary.
     mat_dict = loadmat(filename)
 
     # Convert data into 1d numpy array for easier indexing.
     data = np.squeeze(np.asarray(mat_dict['data']))
 
-    # Extract number of channels and tick rate.
+    # Extract number of channels and tick rate.
     n_channels = len(mat_dict['titles'])
     t_freq = mat_dict['tickrate'][0][0]
 

--- a/phys2bids/interfaces/mat.py
+++ b/phys2bids/interfaces/mat.py
@@ -42,31 +42,75 @@ def populate_phys_input(filename, chtrig):
     # Load MATLAB file into dictionary.
     mat_dict = loadmat(filename)
 
-    # Convert data into 1d numpy array for easier indexing.
-    data = np.squeeze(np.asarray(mat_dict['data']))
+    breakpoint()
+    # See if MATLAB is in ACQ format.
+    if '__header__' in mat_dict:
+        orig_names = mat_dict['labels']
+        orig_units = mat_dict['units']
+        interval = mat_dict['isi'][0][0]
+        interval_units = mat_dict['isi_units'][0]
+        data = mat_dict['data']
 
-    # Extract number of channels and tick rate.
-    n_channels = len(mat_dict['titles'])
-    t_freq = mat_dict['tickrate'][0][0]
+        timeseries = []
+        freq = [t_freq, ]
+        units = ['s', ]
+        names = ['time', ]
 
-    # Stores MATLAB data into lists.
-    timeseries = []
-    freq = [t_freq, ]
-    units = ['s', ]
-    names = ['time', ]
+        if 'Hz' in interval_units:
+            print('frequency is given in the header, calculating sample Interval'
+                ' and standarizing to Hz if needed')
+            freq = float(interval)
+            freq_unit = interval_units
+            if freq_unit == 'MHz':
+                freq = freq * (1000000)
+            elif freq_unit == 'kHz':
+                freq = freq * 1000
+            interval = 1 / freq
+            freq = [freq] * (len(timeseries) + 1)
+        else:
+            # check if interval is in seconds, if not change the units to seconds and
+            # calculate frequency
+            if interval_units != 'sec':
+                LGR.warning('Interval is not in seconds. Converting its value.')
+                if interval_units == 'min':
+                    interval = float(interval) * 60
+                    interval_units = 's'
+                elif interval_units == 'msec':
+                    interval = float(interval) / 1000
+                    interval_units = 's'
+                elif interval_units == 'µsec':
+                    interval = float(interval) / 1000000
+                    interval_units = 's'
+            else:
+                interval = float(interval)
+                interval_units = 's'
+            freq = [1 / interval] * (len(timeseries) + 1)
+    else:
+        # Convert data into 1d numpy array for easier indexing.
+        data = np.squeeze(np.asarray(mat_dict['data']))
 
-    for ch in range(n_channels):
-        units.append(mat_dict['unittext'][int(mat_dict['unittextmap'][ch][0] - 1)].strip())
-        names.append(mat_dict['titles'][ch].strip())
-        freq.append(mat_dict['samplerate'][ch][0])
-        idx_start = int(mat_dict['datastart'][ch])
-        idx_end = int(mat_dict['dataend'][ch])
-        timeseries.append(data[idx_start:idx_end])
+        # Extract number of channels and tick rate.
+        n_channels = len(mat_dict['titles'])
+        t_freq = mat_dict['tickrate'][0][0]
 
-    # Calculate duration based on frequency and create time channel.
-    interval = 1 / t_freq
-    duration = (timeseries[0].shape[0] + 1) * interval
-    t_ch = np.ogrid[0:duration:interval][:-1]
-    timeseries = [t_ch, ] + timeseries
+        # Stores MATLAB data into lists.
+        timeseries = []
+        freq = [t_freq, ]
+        units = ['s', ]
+        names = ['time', ]
+
+        for ch in range(n_channels):
+            units.append(mat_dict['unittext'][int(mat_dict['unittextmap'][ch][0] - 1)].strip())
+            names.append(mat_dict['titles'][ch].strip())
+            freq.append(mat_dict['samplerate'][ch][0])
+            idx_start = int(mat_dict['datastart'][ch])
+            idx_end = int(mat_dict['dataend'][ch])
+            timeseries.append(data[idx_start:idx_end])
+
+        # Calculate duration based on frequency and create time channel.
+        interval = 1 / t_freq
+        duration = (timeseries[0].shape[0] + 1) * interval
+        t_ch = np.ogrid[0:duration:interval][:-1]
+        timeseries = [t_ch, ] + timeseries
 
     return BlueprintInput(timeseries, freq, names, units, chtrig)

--- a/phys2bids/phys2bids.py
+++ b/phys2bids/phys2bids.py
@@ -221,6 +221,8 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
         from phys2bids.interfaces.acq import populate_phys_input
     elif ftype == 'txt':
         from phys2bids.interfaces.txt import populate_phys_input
+    elif ftype == 'mat':
+        from phys2bids.interfaces.mat import populate_phys_input
     else:
         # #!# We should add a logger here.
         raise NotImplementedError('Currently unsupported file type.')

--- a/phys2bids/tests/conftest.py
+++ b/phys2bids/tests/conftest.py
@@ -88,3 +88,8 @@ def notime_lab_file(testpath):
 def multi_run_file(testpath):
     return fetch_file('gvy84', testpath,
                       'Test2_samefreq_TWOscans.txt')
+
+@pytest.fixture
+def matlab_file(testpath):
+    return fetch_file('2j43t', testpath,
+                      'test_2minRest.mat')

--- a/phys2bids/tests/conftest.py
+++ b/phys2bids/tests/conftest.py
@@ -91,5 +91,5 @@ def multi_run_file(testpath):
 
 @pytest.fixture
 def matlab_file(testpath):
-    return fetch_file('2j43t', testpath,
-                      'test_2minRest.mat')
+    return fetch_file('mkgzx', testpath,
+                      'CBD.mat')

--- a/phys2bids/tests/test_integration.py
+++ b/phys2bids/tests/test_integration.py
@@ -233,3 +233,8 @@ def test_integration_multirun(skip_integration, multi_run_file):
     # for run in ['1', '2']:
     #     assert isfile(join(conversion_path, f'Test2_samefreq_TWOscans_{run}_trigger_time.png'))
     assert isfile(join(conversion_path, 'Test2_samefreq_TWOscans.png'))
+
+def test_integration_matlab(matlab_file):
+
+    if skip_integration:
+        pytest.skip('Skipping five-echo integration test')

--- a/phys2bids/tests/test_integration.py
+++ b/phys2bids/tests/test_integration.py
@@ -250,4 +250,3 @@ def test_integration_matlab(skip_integration, matlab_file):
 
     # Check that files are generated in outdir
     base_filename = 'test_2minRest_'
-    breakpoint()

--- a/phys2bids/tests/test_integration.py
+++ b/phys2bids/tests/test_integration.py
@@ -245,72 +245,42 @@ def test_integration_matlab(skip_integration, matlab_file):
     conversion_path = join(test_path, 'code', 'conversion')
 
     phys2bids(filename=test_filename, indir=test_path, outdir=test_path,
-              chtrig=test_chtrig, num_timepoints_expected=100, tr=1.2)
+              chtrig=test_chtrig, num_timepoints_expected=1100, tr=0.555)
 
     # Check that files are generated in outdir.
-    base_filename = 'test_2minRest_'
+    base_filename = 'CBD'
     for suffix in ['.json', '.tsv.gz']:
-        for freq in ['40', '100', '1000']:
-            assert isfile(join(test_path,
-                               f'{base_filename}{freq}Hz{suffix}'))
+        assert isfile(join(test_path,
+                           f'{base_filename}{suffix}'))
 
     # Check that files are generated in conversion path.
-    for freq in ['40', '100', '1000']:
-        assert isfile(join(conversion_path, f'{base_filename}{freq}Hz.log'))
+    assert isfile(join(conversion_path, f'{base_filename}.log'))
 
     # Check that plot is generated in conversion path.
-    assert isfile(join(conversion_path, f'{base_filename[:-1]}.png'))
+    assert isfile(join(conversion_path, f'{base_filename}.png'))
 
-    # ##### Checks for 40 Hz files
     # Read log file (note that this file is not the logger file)
-    log_filename = f'{base_filename}40Hz.log'
+    log_filename = f'{base_filename}.log'
     with open(join(conversion_path, log_filename)) as log_info:
         log_info = log_info.readlines()
 
     # Check timepoints expected
-    assert check_string(log_info, 'Timepoints expected', '100')
+    assert check_string(log_info, 'Timepoints expected', '1100')
     # Check timepoints found
-    assert check_string(log_info, 'Timepoints found', '100')
+    assert check_string(log_info, 'Timepoints found', '1100')
     # Check sampling frequency
-    assert check_string(log_info, 'Sampling Frequency', '40.0')
+    assert check_string(log_info, 'Sampling Frequency', '1000.0')
     # Check sampling started
-    assert check_string(log_info, 'Sampling started', '37.2960')
+    assert check_string(log_info, 'Sampling started', '101.2090')
     # Check first trigger
     assert check_string(log_info, 'first trigger', 'Time 0', is_num=False)
 
     # Checks json file
-    json_filename = f'{base_filename}40Hz.json'
+    json_filename = f'{base_filename}.json'
     with open(join(test_path, json_filename)) as json_file:
         json_data = json.load(json_file)
 
     # Compares values in json file with ground truth
-    assert math.isclose(json_data['SamplingFrequency'], 40.0,)
-    assert math.isclose(json_data['StartTime'], 37.296,)
-    assert json_data['Columns'] == ['time', 'O2']
-
-    # ##### Checks for 100 Hz files
-    # Read log file (note that this file is not the logger file)
-    log_filename = f'{base_filename}100Hz.log'
-    with open(join(conversion_path, log_filename)) as log_info:
-        log_info = log_info.readlines()
-
-    # Check timepoints expected
-    assert check_string(log_info, 'Timepoints expected', '100')
-    # Check timepoints found
-    assert check_string(log_info, 'Timepoints found', '100')
-    # Check sampling frequency
-    assert check_string(log_info, 'Sampling Frequency', '100.0')
-    # Check sampling started
-    assert check_string(log_info, 'Sampling started', '37.2960')
-    # Check first trigger
-    assert check_string(log_info, 'first trigger', 'Time 0', is_num=False)
-
-    # Checks json file
-    json_filename = f'{base_filename}100Hz.json'
-    with open(join(test_path, json_filename)) as json_file:
-        json_data = json.load(json_file)
-
-    # Compares values in json file with ground truth
-    assert math.isclose(json_data['SamplingFrequency'], 100.0,)
-    assert math.isclose(json_data['StartTime'], 37.296,)
-    assert json_data['Columns'] == ['time', 'CO2']
+    assert math.isclose(json_data['SamplingFrequency'], 1000.0,)
+    assert math.isclose(json_data['StartTime'], 101.209,)
+    assert json_data['Columns'] == ['time', 'Trigger', 'CO2', 'O2', 'Pulse']

--- a/phys2bids/tests/test_integration.py
+++ b/phys2bids/tests/test_integration.py
@@ -235,7 +235,6 @@ def test_integration_multirun(skip_integration, multi_run_file):
     assert isfile(join(conversion_path, 'Test2_samefreq_TWOscans.png'))
 
 
-@pytest.mark.xfail
 def test_integration_matlab(skip_integration, matlab_file):
 
     if skip_integration:
@@ -246,7 +245,72 @@ def test_integration_matlab(skip_integration, matlab_file):
     conversion_path = join(test_path, 'code', 'conversion')
 
     phys2bids(filename=test_filename, indir=test_path, outdir=test_path,
-              chtrig=test_chtrig, num_timepoints_expected=534, tr=1.2)
+              chtrig=test_chtrig, num_timepoints_expected=100, tr=1.2)
 
-    # Check that files are generated in outdir
+    # Check that files are generated in outdir.
     base_filename = 'test_2minRest_'
+    for suffix in ['.json', '.tsv.gz']:
+        for freq in ['40', '100', '1000']:
+            assert isfile(join(test_path,
+                               f'{base_filename}{freq}Hz{suffix}'))
+
+    # Check that files are generated in conversion path.
+    for freq in ['40', '100', '1000']:
+        assert isfile(join(conversion_path, f'{base_filename}{freq}Hz.log'))
+
+    # Check that plot is generated in conversion path.
+    assert isfile(join(conversion_path, f'{base_filename[:-1]}.png'))
+
+    # ##### Checks for 40 Hz files
+    # Read log file (note that this file is not the logger file)
+    log_filename = f'{base_filename}40Hz.log'
+    with open(join(conversion_path, log_filename)) as log_info:
+        log_info = log_info.readlines()
+
+    # Check timepoints expected
+    assert check_string(log_info, 'Timepoints expected', '100')
+    # Check timepoints found
+    assert check_string(log_info, 'Timepoints found', '100')
+    # Check sampling frequency
+    assert check_string(log_info, 'Sampling Frequency', '40.0')
+    # Check sampling started
+    assert check_string(log_info, 'Sampling started', '37.2960')
+    # Check first trigger
+    assert check_string(log_info, 'first trigger', 'Time 0', is_num=False)
+
+    # Checks json file
+    json_filename = f'{base_filename}40Hz.json'
+    with open(join(test_path, json_filename)) as json_file:
+        json_data = json.load(json_file)
+
+    # Compares values in json file with ground truth
+    assert math.isclose(json_data['SamplingFrequency'], 40.0,)
+    assert math.isclose(json_data['StartTime'], 37.296,)
+    assert json_data['Columns'] == ['time', 'O2']
+
+    # ##### Checks for 100 Hz files
+    # Read log file (note that this file is not the logger file)
+    log_filename = f'{base_filename}100Hz.log'
+    with open(join(conversion_path, log_filename)) as log_info:
+        log_info = log_info.readlines()
+
+    # Check timepoints expected
+    assert check_string(log_info, 'Timepoints expected', '100')
+    # Check timepoints found
+    assert check_string(log_info, 'Timepoints found', '100')
+    # Check sampling frequency
+    assert check_string(log_info, 'Sampling Frequency', '100.0')
+    # Check sampling started
+    assert check_string(log_info, 'Sampling started', '37.2960')
+    # Check first trigger
+    assert check_string(log_info, 'first trigger', 'Time 0', is_num=False)
+
+    # Checks json file
+    json_filename = f'{base_filename}100Hz.json'
+    with open(join(test_path, json_filename)) as json_file:
+        json_data = json.load(json_file)
+
+    # Compares values in json file with ground truth
+    assert math.isclose(json_data['SamplingFrequency'], 100.0,)
+    assert math.isclose(json_data['StartTime'], 37.296,)
+    assert json_data['Columns'] == ['time', 'CO2']

--- a/phys2bids/tests/test_integration.py
+++ b/phys2bids/tests/test_integration.py
@@ -234,7 +234,20 @@ def test_integration_multirun(skip_integration, multi_run_file):
     #     assert isfile(join(conversion_path, f'Test2_samefreq_TWOscans_{run}_trigger_time.png'))
     assert isfile(join(conversion_path, 'Test2_samefreq_TWOscans.png'))
 
-def test_integration_matlab(matlab_file):
+
+@pytest.mark.xfail
+def test_integration_matlab(skip_integration, matlab_file):
 
     if skip_integration:
-        pytest.skip('Skipping five-echo integration test')
+        pytest.skip('Skipping integration test')
+
+    test_path, test_filename = split(matlab_file)
+    test_chtrig = 1
+    conversion_path = join(test_path, 'code', 'conversion')
+
+    phys2bids(filename=test_filename, indir=test_path, outdir=test_path,
+              chtrig=test_chtrig, num_timepoints_expected=534, tr=1.2)
+
+    # Check that files are generated in outdir
+    base_filename = 'test_2minRest_'
+    breakpoint()

--- a/phys2bids/tests/test_mat.py
+++ b/phys2bids/tests/test_mat.py
@@ -1,4 +1,3 @@
-from phys2bids.tests.conftest import matlab_file
 from phys2bids.interfaces.mat import populate_phys_input
 
 
@@ -8,14 +7,14 @@ def test_populate_phys_input(matlab_file):
     phys_obj = populate_phys_input(matlab_file, chtrig)
 
     # Check channel names are the same.
-    orig_channels = ['time', 'Trigger', 'CO2', 'O2', 'Belt', 'Pulse']
+    orig_channels = ['time', 'Trigger', 'CO2', 'O2', 'Pulse']
     assert phys_obj.ch_name == orig_channels
 
     # Check frequencies are the same.
-    orig_freq = [1000.0, 1000.0, 100.0, 40.0, 400.0, 1000.0]
+    orig_freq = [1000.0, 1000.0, 1000.0, 1000.0, 1000.0]
     assert phys_obj.freq == orig_freq
 
     # Check units are the same
-    orig_units = ['s', 'V', 'mmHg', 'mmHg', 'V', 'V']
+    orig_units = ['s', 'V', 'mmHg', 'mmHg', 'V']
     assert phys_obj.units == orig_units
 

--- a/phys2bids/tests/test_mat.py
+++ b/phys2bids/tests/test_mat.py
@@ -1,0 +1,21 @@
+from phys2bids.tests.conftest import matlab_file
+from phys2bids.interfaces.mat import populate_phys_input
+
+
+def test_populate_phys_input(matlab_file):
+    # Read data to test
+    chtrig = 1
+    phys_obj = populate_phys_input(matlab_file, chtrig)
+
+    # Check channel names are the same.
+    orig_channels = ['time', 'Trigger', 'CO2', 'O2', 'Belt', 'Pulse']
+    assert phys_obj.ch_name == orig_channels
+
+    # Check frequencies are the same.
+    orig_freq = [1000.0, 1000.0, 100.0, 40.0, 400.0, 1000.0]
+    assert phys_obj.freq == orig_freq
+
+    # Check units are the same
+    orig_units = ['s', 'V', 'mmHg', 'mmHg', 'V', 'V']
+    assert phys_obj.units == orig_units
+

--- a/phys2bids/utils.py
+++ b/phys2bids/utils.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 LGR = logging.getLogger(__name__)
 
-SUPPORTED_FTYPES = ('acq', 'txt')  # 'mat', ...
+SUPPORTED_FTYPES = ('acq', 'txt', 'mat')
 
 
 def check_input_dir(indir):

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,8 @@ doc =
     sphinx >=2.0
     sphinx-argparse
     sphinx_rtd_theme
+mat =
+    scipy>=1.5
 style =
     flake8 >=3.7
     flake8-docstrings >=1.5
@@ -48,6 +50,7 @@ test =
     pytest >=5.3
     pytest-cov
     %(acq)s
+    %(mat)s
     %(style)s
 interfaces =
     %(acq)s
@@ -55,6 +58,7 @@ all =
     %(doc)s
     %(duecredit)s
     %(interfaces)s
+    %(mat)s
     %(style)s
     %(test)s
 


### PR DESCRIPTION
Closes #25

## Proposed Changes

  - Create a MATLAB interface to read MATLAB files and transform them into `BlueprintInput` objects.
  - Add unit tests for the MATLAB interface.
  - Add integration test for a MATLAB file.