### PR TITLE
Change build shield from Travis to CircleCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ phys2bids
 [![Join the chat at Gitter: https://gitter.im/physiopy/phys2bids](https://badges.gitter.im/physiopy/phys2bids.svg)](https://gitter.im/physiopy/phys2bids?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=body_badge)
 [![codecov](https://codecov.io/gh/physiopy/phys2bids/branch/master/graph/badge.svg)](https://codecov.io/gh/physiopy/phys2bids)
 
-[![Build Status: Linux](https://travis-ci.org/physiopy/phys2bids.svg?branch=master)](https://travis-ci.org/physiopy/phys2bids)
+[![CircleCI](https://circleci.com/gh/physiopy/phys2bids.svg?style=shield)](https://circleci.com/gh/physiopy/phys2bids)
 [![Build Status. Windows](https://dev.azure.com/physiopy/phys2bids/_apis/build/status/physiopy.phys2bids?branchName=master)](https://dev.azure.com/physiopy/phys2bids/_build/latest?definitionId=1&branchName=master)
 [![See the documentation at: https://phys2bids.readthedocs.io](https://readthedocs.org/projects/phys2bids/badge/?version=latest)](https://phys2bids.readthedocs.io/en/latest/?badge=latest)
 [![Requirements Status](https://requires.io/github/physiopy/phys2bids/requirements.svg?branch=master)](https://requires.io/github/physiopy/phys2bids/requirements/?branch=master)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ phys2bids
 [![Join the chat at Gitter: https://gitter.im/physiopy/phys2bids](https://badges.gitter.im/physiopy/phys2bids.svg)](https://gitter.im/physiopy/phys2bids?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=body_badge)
 [![codecov](https://codecov.io/gh/physiopy/phys2bids/branch/master/graph/badge.svg)](https://codecov.io/gh/physiopy/phys2bids)
 
-[![CircleCI](https://circleci.com/gh/physiopy/phys2bids.svg?style=shield)](https://circleci.com/gh/physiopy/phys2bids)
+[![CircleCI](https://circleci.com/gh/physiopy/phys2bids.svg?branch=master&style=shield)](https://circleci.com/gh/physiopy/phys2bids)
 [![Build Status. Windows](https://dev.azure.com/physiopy/phys2bids/_apis/build/status/physiopy.phys2bids?branchName=master)](https://dev.azure.com/physiopy/phys2bids/_build/latest?definitionId=1&branchName=master)
 [![See the documentation at: https://phys2bids.readthedocs.io](https://readthedocs.org/projects/phys2bids/badge/?version=latest)](https://phys2bids.readthedocs.io/en/latest/?badge=latest)
 [![Requirements Status](https://requires.io/github/physiopy/phys2bids/requirements.svg?branch=master)](https://requires.io/github/physiopy/phys2bids/requirements/?branch=master)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,13 +10,13 @@ phys2bids
     :target: https://doi.org/10.5281/zenodo.3653153
     :alt: DOI
 
-.. image:: https://circleci.com/gh/physiopy/phys2bids.svg?branch=master&style=shield
-    :target: https://circleci.com/gh/physiopy/phys2bids
-    :alt: Build status
-
 .. image:: https://badges.gitter.im/phys2bids/community.svg
     :target: https://badges.gitter.im/phys2bids/community.svg)](https://gitter.im/phys2bids/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
     :alt: Join the chat at https://gitter.im/phys2bids/community
+
+.. image:: https://circleci.com/gh/physiopy/phys2bids.svg?branch=master&style=shield
+    :target: https://circleci.com/gh/physiopy/phys2bids
+    :alt: Build status
 
 .. image:: https://readthedocs.org/projects/phys2bids/badge/?version=latest
     :target: https://phys2bids.readthedocs.io/en/latest/?badge=latest

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,8 +10,8 @@ phys2bids
     :target: https://doi.org/10.5281/zenodo.3653153
     :alt: DOI
 
-.. image:: https://travis-ci.org/physiopy/phys2bids.svg?branch=master
-    :target: https://travis-ci.org/physiopy/phys2bids
+.. image:: https://circleci.com/gh/physiopy/phys2bids.svg?branch=master&style=shield
+    :target: https://circleci.com/gh/physiopy/phys2bids
     :alt: Build status
 
 .. image:: https://badges.gitter.im/phys2bids/community.svg


### PR DESCRIPTION
Closes #296

## Proposed Changes

  - Change link to Travis CI for the link to CircleCI to display correct build shield.