### PR TITLE
Refractor txt.py chtrig parameter to improve code readability

### DIFF
--- a/phys2bids/interfaces/txt.py
+++ b/phys2bids/interfaces/txt.py
@@ -149,7 +149,7 @@ def process_labchart(channel_list, chtrig, header=[]):
     units = units + orig_units
     freq = [1 / interval[0]] * len(timeseries)
     freq = check_multifreq(timeseries, freq)
-    return BlueprintInput(timeseries, freq, names, units, chtrig + 1)
+    return BlueprintInput(timeseries, freq, names, units, chtrig)
 
 
 def process_acq(channel_list, chtrig, header=[]):
@@ -248,7 +248,7 @@ def process_acq(channel_list, chtrig, header=[]):
     t_ch = np.ogrid[0:duration:interval[0]][:-1]  # create time channel
     timeseries = [t_ch, ] + timeseries
     freq = check_multifreq(timeseries, freq)
-    return BlueprintInput(timeseries, freq, names, units, chtrig + 1)
+    return BlueprintInput(timeseries, freq, names, units, chtrig)
 
 
 def read_header_and_channels(filename):
@@ -319,7 +319,6 @@ def populate_phys_input(filename, chtrig):
     --------
     physio_obj.BlueprintInput
     """
-    chtrig = chtrig - 1  # now for the user channel indexing starts at 1 as it
     # happens in acq call
     header, channel_list = read_header_and_channels(filename, chtrig)
     # check header is not empty and detect if it is in labchart or Acqknoledge format

--- a/phys2bids/interfaces/txt.py
+++ b/phys2bids/interfaces/txt.py
@@ -76,7 +76,7 @@ def process_labchart(channel_list, chtrig, header=[]):
     channel_list: list
         list with channels only
     chtrig : int
-        index of trigger channel
+        index of trigger channel, starting in 1 for human readability
     header: list
         list with that contains file header
 
@@ -161,7 +161,7 @@ def process_acq(channel_list, chtrig, header=[]):
     channel_list: list
         list with channels only
     chtrig : int
-        index of trigger channel
+        index of trigger channel, starting in 1 for human readability
     header: list
         list with that contains file header
 
@@ -303,7 +303,7 @@ def populate_phys_input(filename, chtrig):
     filename: str
         path to the txt Labchart file
     chtrig : int
-        index of trigger channel
+        index of trigger channel, starting in 1 for human readability
 
     Returns
     -------

--- a/phys2bids/interfaces/txt.py
+++ b/phys2bids/interfaces/txt.py
@@ -251,7 +251,7 @@ def process_acq(channel_list, chtrig, header=[]):
     return BlueprintInput(timeseries, freq, names, units, chtrig + 1)
 
 
-def read_header_and_channels(filename, chtrig):
+def read_header_and_channels(filename):
     """
     Read a txt file with a header and channels and separate them.
 
@@ -259,8 +259,6 @@ def read_header_and_channels(filename, chtrig):
     ----------
     filename: str
         path to the txt Labchart file
-    chtrig : int
-        index of trigger channel
 
     Returns
     -------

--- a/phys2bids/interfaces/txt.py
+++ b/phys2bids/interfaces/txt.py
@@ -320,7 +320,7 @@ def populate_phys_input(filename, chtrig):
     physio_obj.BlueprintInput
     """
     # happens in acq call
-    header, channel_list = read_header_and_channels(filename, chtrig)
+    header, channel_list = read_header_and_channels(filename)
     # check header is not empty and detect if it is in labchart or Acqknoledge format
     if len(header) == 0:
         raise AttributeError('Files without header are not supported yet')

--- a/phys2bids/tests/test_txt.py
+++ b/phys2bids/tests/test_txt.py
@@ -9,7 +9,7 @@ from phys2bids.interfaces import txt
 @pytest.fixture(scope='function')
 def loaded_acq_file(samefreq_short_txt_file):
     chtrig = 2
-    header_acq, channels_acq = txt.read_header_and_channels(samefreq_short_txt_file, chtrig)
+    header_acq, channels_acq = txt.read_header_and_channels(samefreq_short_txt_file)
 
     # just a few quick checks to make sure the data loaded correctly
     assert len(header_acq) == 8  # check proper header lenght
@@ -23,7 +23,7 @@ def loaded_acq_file(samefreq_short_txt_file):
 @pytest.fixture(scope='function')
 def loaded_lab_file(multifreq_lab_file):
     chtrig = 1
-    header_lab, channels_lab = txt.read_header_and_channels(multifreq_lab_file, chtrig)
+    header_lab, channels_lab = txt.read_header_and_channels(multifreq_lab_file)
 
     # just a few quick checks to make sure the data loaded correctly
     assert len(channels_lab[0]) == 5
@@ -55,7 +55,7 @@ def test_process_labchart(loaded_lab_file, units, expected):
 
 def test_process_labchart_notime(notime_lab_file):
     chtrig = 0
-    header, channels = txt.read_header_and_channels(notime_lab_file, chtrig)
+    header, channels = txt.read_header_and_channels(notime_lab_file)
     phys_obj = txt.process_labchart(channels, chtrig=chtrig, header=header)
     assert len(phys_obj.timeseries) == len(channels[0]) + 1
 
@@ -115,7 +115,7 @@ def test_noheader_acq_error(samefreq_noheader_txt_file):
     assert 'not supported' in str(errorinfo.value)
 
     # test file without header for process_acq
-    header, channels = txt.read_header_and_channels(samefreq_noheader_txt_file, chtrig)
+    header, channels = txt.read_header_and_channels(samefreq_noheader_txt_file)
     with raises(AttributeError) as errorinfo:
         txt.process_acq(channels, chtrig=chtrig)
     assert 'not supported' in str(errorinfo.value)


### PR DESCRIPTION
Closes #273

## Proposed Changes
 quick, very neat refactoring to lower the chances of confusion while reading the code:
- Delete [line 322](https://github.com/physiopy/phys2bids/blob/a2493bf383d3a7668c549099215bd3ddd60f8831/phys2bids/interfaces/txt.py#L322)
- Remove chtrig from [this definition's argoments](https://github.com/physiopy/phys2bids/blob/a2493bf383d3a7668c549099215bd3ddd60f8831/phys2bids/interfaces/txt.py#L254), since it's not used in the definition itself.
- Change `chtrig +1` in [this line](https://github.com/physiopy/phys2bids/blob/a2493bf383d3a7668c549099215bd3ddd60f8831/phys2bids/interfaces/txt.py#L152) and in [this line](https://github.com/physiopy/phys2bids/blob/a2493bf383d3a7668c549099215bd3ddd60f8831/phys2bids/interfaces/txt.py#L251) into `chtrig` only.
- Add explanation of `chtrig` indexing starting from 1 for human readability in all the docstrings.