### PR TITLE
add format parameter to the logger

### DIFF
--- a/phys2bids/phys2bids.py
+++ b/phys2bids/phys2bids.py
@@ -169,13 +169,13 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
 
     if quiet:
         logging.basicConfig(level=logging.WARNING,
-                            handlers=[log_handler, sh])
+                            handlers=[log_handler, sh], format='%(levelname)s:\t%(message)s')
     elif debug:
         logging.basicConfig(level=logging.DEBUG,
-                            handlers=[log_handler, sh])
+                            handlers=[log_handler, sh], format='%(levelname)s:\t%(message)s')
     else:
         logging.basicConfig(level=logging.INFO,
-                            handlers=[log_handler, sh])
+                            handlers=[log_handler, sh], format='%(levelname)s:\t%(message)s')
 
     version_number = _version.get_versions()['version']
     LGR.info(f'Currently running phys2bids version {version_number}')


### PR DESCRIPTION
Closes #196 

## Proposed Changes

  - adds the parameter ``format='%(levelname)s:\t%(message)s')`` to the logger
  - Results:
![image](https://user-images.githubusercontent.com/38909338/95553666-47c7dd80-0a0f-11eb-8d57-474d8ec28dad.png)
