### PR TITLE
Setup auto release workflow

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -3,6 +3,7 @@
   "projectOwner": "physiopy",
   "repoType": "github",
   "repoHost": "https://github.com",
+  "skipCi": true,
   "files": [
     "README.md"
   ],

--- a/.autorc
+++ b/.autorc
@@ -1,0 +1,86 @@
+{
+  "plugins": [
+    "git-tag",
+    "all-contributors",
+    "conventional-commits",
+    "first-time-contributor",
+    "released"
+  ],
+  "release": {
+    "prerelease": true
+  },
+  "owner": "physiopy",
+  "repo": "phys2bids",
+  "name": "Stefano Moia",
+  "email": "s.moia@bcbl.eu",
+  "labels": [
+    {
+      "name": "Majormod",
+      "changelogTitle": "💥 Breaking Change",
+      "description": "This PR breaks compatibility, and increments the major version (+1.0.0)",
+      "releaseType": "major",
+      "overwrite": true
+    },
+    {
+      "name": "Minormod",
+      "changelogTitle": "🚀 Enhancement",
+      "description": "This PR generally closes an `Enhancement` issue. It increments the minor version (0.+1.0)",
+      "releaseType": "minor",
+      "overwrite": true
+    },
+    {
+      "name": "Minormod-breaking",
+      "changelogTitle": "💥 Breaking Change during development",
+      "description": "For development only, this PR increments the minor version (0.+1.0) but breaks compatibility",
+      "releaseType": "minor",
+      "overwrite": true
+    },
+    {
+      "name": "BugFIX",
+      "changelogTitle": "🐛 Bug Fix",
+      "description": "This PR generally closes a `Bug` issue, and increments the patch version (0.0.+1)",
+      "releaseType": "patch",
+      "overwrite": true
+    },
+    {
+      "name": "Documentation",
+      "changelogTitle": "📝 Documentation",
+      "description": "This issue or PR is about the documentation ",
+      "releaseType": "none",
+      "overwrite": true
+    },
+    {
+      "name": "Testing",
+      "changelogTitle": "⚠️ Tests",
+      "description": "This is for testing features, writing tests or producing testing code",
+      "releaseType": "none",
+      "overwrite": true
+    },
+    {
+      "name": "Internal",
+      "changelogTitle": "🏠 Internal",
+      "description": "Changes affect the internal API. It doesn't increase the version, but produces a changelog",
+      "releaseType": "none",
+      "overwrite": true
+    },
+    {
+      "name": "Outreach",
+      "changelogTitle": "🖋️  Outreach",
+      "description": "Issue about outreaching of any form",
+      "releaseType": "none",
+      "overwrite": true
+    },
+    {
+      "name": "Skip release",
+      "description": "This PR preserves the current version when merged, and doesn't appear in the changelog",
+      "releaseType": "skip",
+      "overwrite": true
+    },
+    {
+      "name": "Release",
+      "description": "For PR only, trigger a release at the merge",
+      "releaseType": "release",
+      "overwrite": true
+    }
+  ]
+}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,43 @@
+# This workflows will create a release using auto when a PR is merged in master.
+
+name: Auto-release on PR merge
+
+on:
+  # ATM, this is the closest trigger to a PR merging
+  push:
+    branches:
+      - master
+
+jobs:
+  auto-release:
+    runs-on: ubuntu-18.04
+    # Set skip ci to avoid loops
+    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
+    # Set bash as default shell for jobs
+    defaults:
+      run:
+        shell: bash
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v2
+      with:
+        # Fetch all history for all branches and tags
+        fetch-depth: 0
+        # Use token with write access to the repo
+        token: ${{ secrets.GH_TOKEN }}
+    - name: Download and install latest auto
+      env:
+        # OS can be linux, macos, or win
+        OS: linux
+        # Retrieve URL of latest auto, download it, unzip it, and give exec permissions.
+      run: |
+        curl -vkL -o - $( curl -s https://api.github.com/repos/intuit/auto/releases/latest \
+        | grep browser_download_url | grep ${OS} | awk -F'"' '{print $4}') \
+        | gunzip > ~/auto
+        chmod a+x ~/auto
+    - name: Create release without version prefix
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        # Run auto release, don't use 'v' prefix, and be ultraverbose
+      run: |
+        ~/auto release --no-version-prefix -vv

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ phys2bids
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3653153.svg)](https://doi.org/10.5281/zenodo.3653153)
 [![Join the chat at Gitter: https://gitter.im/physiopy/phys2bids](https://badges.gitter.im/physiopy/phys2bids.svg)](https://gitter.im/physiopy/phys2bids?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=body_badge)
 [![codecov](https://codecov.io/gh/physiopy/phys2bids/branch/master/graph/badge.svg)](https://codecov.io/gh/physiopy/phys2bids)
+[![Auto Release](https://img.shields.io/badge/release-auto.svg?colorA=888888&colorB=9B065A&label=auto)](https://github.com/intuit/auto)
 
 [![CircleCI](https://circleci.com/gh/physiopy/phys2bids.svg?branch=master&style=shield)](https://circleci.com/gh/physiopy/phys2bids)
 [![Build Status. Windows](https://dev.azure.com/physiopy/phys2bids/_apis/build/status/physiopy.phys2bids?branchName=master)](https://dev.azure.com/physiopy/phys2bids/_build/latest?definitionId=1&branchName=master)

--- a/codecov.yml
+++ b/codecov.yml
@@ -29,6 +29,8 @@ ignore:
   - "phys2bids/tests"
   - "phys2bids/heuristics"
   - "phys2bids/due.py"
+  - ".*rc"
+  - ".github"
 
 comment:
   layout: "reach,diff,flags,tree"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,9 @@ phys2bids
     :target: https://codecov.io/gh/physiopy/phys2bids
     :alt: codecov
 
+.. image:: https://img.shields.io/badge/release-auto.svg?colorA=888888&colorB=9B065A&label=auto
+    :target: https://github.com/intuit/auto
+    :alt: Auto Release
 
 ``phys2bids`` is a python3 library meant to format physiological files in BIDS.
 It was born for AcqKnowledge files (BIOPAC), and at the moment it supports


### PR DESCRIPTION
Closes #311 and closes #239

Second attempt to integrate `auto` as a workflow, this time as a GitHub action. IF this works, we have a great automated workflow from PR merge to Pypi package (with the other workflow).

## Proposed Changes

  - Add `.autorc` configuration file
  - Add github workflow that * should * retrieve the latest version of auto (might not be elegant) and then run it 
  - Add a couple of badges.

I can't wait to see if this works. So exciting!

@hipstersmoothie, could you please have a look at this PR?
@yarikoptic and @jwodder, you could have a look into this too - if you implemented a different solution I'd like to compare them, and otherwise if this works it should help you with datalad/datalad#4999 and dandi/dandi-cli#252!