### PR TITLE
Add Main Reviewer checklist

### DIFF
--- a/.github/workflows/main-reviewer.yml
+++ b/.github/workflows/main-reviewer.yml
@@ -14,13 +14,13 @@ jobs:
     steps:
     - name: Replace reviewer name in message template
       uses: falnyr/replace-env-vars-action@master
-          # This is a wild guess. Probably it's also wrong.
-        env:
-          MAINREV: ${{ github.event.issue.assignees }}
-        with: .github/workflows/main_rev_checklist.md
+      env:
+      # This is a wild guess. Probably it's also wrong.
+        MAINREV: ${{ github.event.issue.assignees }}
+      with: .github/workflows/main_rev_checklist.md
     - name: Post filled template as comment
       uses: harupy/comment-on-pr@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        with:
-          filename: main_rev_checklist.md
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      with:
+        filename: main_rev_checklist.md

--- a/.github/workflows/main-reviewer.yml
+++ b/.github/workflows/main-reviewer.yml
@@ -1,13 +1,13 @@
 # This workflows print a message to give the Main Reviewer a checklist (before merge)
 
-name: Main Reviewer
+name: Main Reviewer Checklist
 
 on:
   pull_request:
     types: [assigned]
 
 jobs:
-  deploy:
+  checklist:
     # Not totally sure we need this
     runs-on: ubuntu-18.04
 
@@ -15,6 +15,7 @@ jobs:
     - name: Replace reviewer name in message template
       uses: falnyr/replace-env-vars-action@master
         env:
+          # This is a wild guess. Probably it's also wrong.
           MAINREV: ${{ github.event.issue.assignees }}
         with: .github/workflows/main_rev_checklist.md
     - name: Post filled template as comment

--- a/.github/workflows/main-reviewer.yml
+++ b/.github/workflows/main-reviewer.yml
@@ -1,0 +1,25 @@
+# This workflows print a message to give the Main Reviewer a checklist (before merge)
+
+name: Main Reviewer
+
+on:
+  pull_request:
+    types: [assigned]
+
+jobs:
+  deploy:
+    # Not totally sure we need this
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Replace reviewer name in message template
+      uses: falnyr/replace-env-vars-action@master
+        env:
+          MAINREV: ${{ github.event.issue.assignees }}
+        with: .github/workflows/main_rev_checklist.md
+    - name: Post filled template as comment
+      uses: harupy/comment-on-pr@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          filename: main_rev_checklist.md

--- a/.github/workflows/main-reviewer.yml
+++ b/.github/workflows/main-reviewer.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
     - name: Replace reviewer name in message template
       uses: falnyr/replace-env-vars-action@master
-        env:
           # This is a wild guess. Probably it's also wrong.
+        env:
           MAINREV: ${{ github.event.issue.assignees }}
         with: .github/workflows/main_rev_checklist.md
     - name: Post filled template as comment

--- a/.github/workflows/main_rev_checklist.md
+++ b/.github/workflows/main_rev_checklist.md
@@ -1,0 +1,25 @@
+Hello @__MAINREV__!
+
+You've been assigned to this PR, which means that you've been nominated Main Reviewer! (Lucky you! :ta-da: :ta-da: :ta-da:)
+
+As a Main Reviewer, you are a bit more responsible for the quality of this PR and of the project in general than your fellow Reviewers. If you have any doubt, check [this section on reviewing](https://phys2bids.readthedocs.io/en/latest/contributorfile.html#reviewing) and [this section on being the Main Reviewer](https://phys2bids.readthedocs.io/en/latest/contributorfile.html#mainreviewer) of the documents.
+
+Before merging this PR, please check that:
+- [ ] The PR passes all the CircleCI/Azure tests.
+- [ ] The content respects the [Style Guide](https://phys2bids.readthedocs.io/en/latest/contributorfile.html#styling).
+- [ ] If the PR contains documentation, your local build is right.
+- If the PR contains code changes:
+    - [ ] Content and changes are adequately documented in the docstrings.
+    - [ ] User documentation is being updated accordingly - or a related issue has been opened.
+    - [ ] The adequate tests have been added/updated - or a related issue has been opened *if coverage doesn't drop below 90%*.
+- [ ] The PR and the reviews are harmonious with the rest of the repository, especially in that **they don't introduce repetitions**
+- [ ] The title of the PR is clear enough to describe a release content.
+- [ ] The labels are correct - and they will (or won't) trigger the correct `auto` release.
+- [ ] The PR received the amount of approvals necessaries to be merged.
+
+After you merged this PR, please check that:
+- [ ] The Author(s) and Reviewers contributions have been updated in the README.
+- [ ] The updates (in code, tests and documentation) have appened correctly.
+- [ ] If they had to, the tag was created, the release was cut, and the pypi version got updated.
+
+Thank you!


### PR DESCRIPTION
Closes none, depends on #315 

This is a draft because I'm not _totally_ sure the workflow is right.

## Proposed Changes

  - Add a GH Action to create comment addressing the main reviewer when a PR gets assigned.
  - Add the template to provide the main reviewer with a checklist of things to do before (and after) merging.