### PR TITLE
Adopt Black and isort

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,10 +97,8 @@ jobs:
           pkg-manager: pip-dist
       - run:
           name: Check style
-          command: echo "Skipping for now"  # |
-            # isort --check .
-            # black --check phys2bids
-            # flake8 ./phys2bids
+          command: |
+            flake8 ./phys2bids
 
   merge_coverage:
     working_directory: /tmp/src/phys2bids

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,9 @@ jobs:
       - run:
           name: Check style
           command: |
-            flake8 ./phys2bids
+            isort --check .
+            black --check nigsp
+            flake8 ./nigsp
 
   merge_coverage:
     working_directory: /tmp/src/phys2bids

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,8 +99,8 @@ jobs:
           name: Check style
           command: |
             isort --check .
-            black --check nigsp
-            flake8 ./nigsp
+            black --check phys2bids
+            flake8 ./phys2bids
 
   merge_coverage:
     working_directory: /tmp/src/phys2bids

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,14 @@ repos:
     -   id: check-added-large-files
     -   id: check-case-conflict
     -   id: check-merge-conflict
+-   repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+    -   id: black
+-   repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+    -   id: isort
 -   repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     -   id: isort
 -   repo: https://github.com/pycqa/flake8

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,6 +7,7 @@
 
 import os
 import sys
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/phys2bids/__init__.py
+++ b/phys2bids/__init__.py
@@ -1,4 +1,5 @@
 """Main init for phys2bids package."""
 from ._version import get_versions
-__version__ = get_versions()['version']
+
+__version__ = get_versions()["version"]
 del get_versions

--- a/phys2bids/_version.py
+++ b/phys2bids/_version.py
@@ -1,4 +1,3 @@
-
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -58,17 +57,18 @@ HANDLERS = {}
 
 def register_vcs_handler(vcs, method):  # decorator
     """Mark a method as the handler for a particular VCS."""
+
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:
             HANDLERS[vcs] = {}
         HANDLERS[vcs][method] = f
         return f
+
     return decorate
 
 
-def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
-                env=None):
+def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=None):
     """Call the given command(s)."""
     assert isinstance(commands, list)
     p = None
@@ -76,10 +76,13 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
         try:
             dispcmd = str([c] + args)
             # remember shell=False, so use git.cmd on windows, not just git
-            p = subprocess.Popen([c] + args, cwd=cwd, env=env,
-                                 stdout=subprocess.PIPE,
-                                 stderr=(subprocess.PIPE if hide_stderr
-                                         else None))
+            p = subprocess.Popen(
+                [c] + args,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=(subprocess.PIPE if hide_stderr else None),
+            )
             break
         except EnvironmentError:
             e = sys.exc_info()[1]
@@ -116,16 +119,22 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     for i in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
-            return {"version": dirname[len(parentdir_prefix):],
-                    "full-revisionid": None,
-                    "dirty": False, "error": None, "date": None}
+            return {
+                "version": dirname[len(parentdir_prefix) :],
+                "full-revisionid": None,
+                "dirty": False,
+                "error": None,
+                "date": None,
+            }
         else:
             rootdirs.append(root)
             root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print("Tried directories %s but none started with prefix %s" %
-              (str(rootdirs), parentdir_prefix))
+        print(
+            "Tried directories %s but none started with prefix %s"
+            % (str(rootdirs), parentdir_prefix)
+        )
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 
@@ -181,7 +190,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    tags = set([r[len(TAG) :] for r in refs if r.startswith(TAG)])
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -190,7 +199,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r'\d', r)])
+        tags = set([r for r in refs if re.search(r"\d", r)])
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -198,19 +207,26 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
-            r = ref[len(tag_prefix):]
+            r = ref[len(tag_prefix) :]
             if verbose:
                 print("picking %s" % r)
-            return {"version": r,
-                    "full-revisionid": keywords["full"].strip(),
-                    "dirty": False, "error": None,
-                    "date": date}
+            return {
+                "version": r,
+                "full-revisionid": keywords["full"].strip(),
+                "dirty": False,
+                "error": None,
+                "date": date,
+            }
     # no suitable tags, so version is "0+unknown", but full hex is still there
     if verbose:
         print("no suitable tags, using unknown + full revision id")
-    return {"version": "0+unknown",
-            "full-revisionid": keywords["full"].strip(),
-            "dirty": False, "error": "no suitable tags", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": keywords["full"].strip(),
+        "dirty": False,
+        "error": "no suitable tags",
+        "date": None,
+    }
 
 
 @register_vcs_handler("git", "pieces_from_vcs")
@@ -225,8 +241,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
 
-    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root,
-                          hide_stderr=True)
+    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root, hide_stderr=True)
     if rc != 0:
         if verbose:
             print("Directory %s not under git control" % root)
@@ -234,10 +249,11 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
-                                          "--always", "--long",
-                                          "--match", "%s*" % tag_prefix],
-                                   cwd=root)
+    describe_out, rc = run_command(
+        GITS,
+        ["describe", "--tags", "--dirty", "--always", "--long", "--match", "%s*" % tag_prefix],
+        cwd=root,
+    )
     # --long was added in git-1.5.5
     if describe_out is None:
         raise NotThisMethod("'git describe' failed")
@@ -260,17 +276,16 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     dirty = git_describe.endswith("-dirty")
     pieces["dirty"] = dirty
     if dirty:
-        git_describe = git_describe[:git_describe.rindex("-dirty")]
+        git_describe = git_describe[: git_describe.rindex("-dirty")]
 
     # now we have TAG-NUM-gHEX or HEX
 
     if "-" in git_describe:
         # TAG-NUM-gHEX
-        mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
+        mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
         if not mo:
             # unparsable. Maybe git-describe is misbehaving?
-            pieces["error"] = ("unable to parse git-describe output: '%s'"
-                               % describe_out)
+            pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
             return pieces
 
         # tag
@@ -279,10 +294,9 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
-                               % (full_tag, tag_prefix))
+            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (full_tag, tag_prefix)
             return pieces
-        pieces["closest-tag"] = full_tag[len(tag_prefix):]
+        pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
         # distance: number of commits since tag
         pieces["distance"] = int(mo.group(2))
@@ -293,13 +307,11 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     else:
         # HEX: no tags
         pieces["closest-tag"] = None
-        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
-                                    cwd=root)
+        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"], cwd=root)
         pieces["distance"] = int(count_out)  # total number of commits
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()
-    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"],
-                       cwd=root)[0].strip()
+    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"], cwd=root)[0].strip()
     pieces["date"] = date.strip().replace(" ", "T", 1).replace(" ", "", 1)
 
     return pieces
@@ -330,8 +342,7 @@ def render_pep440(pieces):
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -445,11 +456,13 @@ def render_git_describe_long(pieces):
 def render(pieces, style):
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
-        return {"version": "unknown",
-                "full-revisionid": pieces.get("long"),
-                "dirty": None,
-                "error": pieces["error"],
-                "date": None}
+        return {
+            "version": "unknown",
+            "full-revisionid": pieces.get("long"),
+            "dirty": None,
+            "error": pieces["error"],
+            "date": None,
+        }
 
     if not style or style == "default":
         style = "pep440"  # the default
@@ -469,9 +482,13 @@ def render(pieces, style):
     else:
         raise ValueError("unknown style '%s'" % style)
 
-    return {"version": rendered, "full-revisionid": pieces["long"],
-            "dirty": pieces["dirty"], "error": None,
-            "date": pieces.get("date")}
+    return {
+        "version": rendered,
+        "full-revisionid": pieces["long"],
+        "dirty": pieces["dirty"],
+        "error": None,
+        "date": pieces.get("date"),
+    }
 
 
 def get_versions():
@@ -485,8 +502,7 @@ def get_versions():
     verbose = cfg.verbose
 
     try:
-        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix,
-                                          verbose)
+        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix, verbose)
     except NotThisMethod:
         pass
 
@@ -495,13 +511,16 @@ def get_versions():
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for i in cfg.versionfile_source.split('/'):
+        for i in cfg.versionfile_source.split("/"):
             root = os.path.dirname(root)
     except NameError:
-        return {"version": "0+unknown", "full-revisionid": None,
-                "dirty": None,
-                "error": "unable to find root of source tree",
-                "date": None}
+        return {
+            "version": "0+unknown",
+            "full-revisionid": None,
+            "dirty": None,
+            "error": "unable to find root of source tree",
+            "date": None,
+        }
 
     try:
         pieces = git_pieces_from_vcs(cfg.tag_prefix, root, verbose)
@@ -515,6 +534,10 @@ def get_versions():
     except NotThisMethod:
         pass
 
-    return {"version": "0+unknown", "full-revisionid": None,
-            "dirty": None,
-            "error": "unable to compute version", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": None,
+        "dirty": None,
+        "error": "unable to compute version",
+        "date": None,
+    }

--- a/phys2bids/bids.py
+++ b/phys2bids/bids.py
@@ -254,9 +254,9 @@ def participants_file(outdir, yml, sub):
                     break
         # Only append to file if subject is not in the file
         if not sub_exists:
-            LGR.info(f'Appending subject sub-{sub} to participants.tsv ...')
-            participants_data = ['n/a'] * header_length
-            participants_data[p_id_idx] = f'sub-{sub}'
+            LGR.info(f"Appending subject sub-{sub} to participants.tsv ...")
+            participants_data = ["n/a"] * header_length
+            participants_data[p_id_idx] = f"sub-{sub}"
             utils.append_list_as_row(file_path, participants_data)
 
 

--- a/phys2bids/bids.py
+++ b/phys2bids/bids.py
@@ -10,6 +10,7 @@ from phys2bids import utils
 
 LGR = logging.getLogger(__name__)
 
+# fmt: off
 UNIT_ALIASES = {
                 # kelvin: thermodynamic temperature
                 'kelvin': 'K', 'kelvins': 'K',
@@ -51,6 +52,7 @@ PREFIX_ALIASES = {
                     'f': 'f', 'femto': 'f', 'a': 'a', 'atto': 'a',
                     'z': 'z', 'zepto': 'z', 'y': 'y', 'yocto': 'y',
 }
+# fmt: on
 
 
 def bidsify_units(orig_unit):
@@ -81,26 +83,26 @@ def bidsify_units(orig_unit):
         # check that u_key is part of unit
         if unit.endswith(u_key):
             new_unit = UNIT_ALIASES[u_key]
-            unit = unit[:-len(u_key)]
-            if unit != '':
+            unit = unit[: -len(u_key)]
+            if unit != "":
                 # for every prefix alias
-                prefix = PREFIX_ALIASES.get(unit, '')
-                if prefix == '':
-                    LGR.warning(f'The given unit prefix {unit} does not '
-                                'have aliases, passing it as is')
-                    prefix = orig_unit[:len(unit)]
+                prefix = PREFIX_ALIASES.get(unit, "")
+                if prefix == "":
+                    LGR.warning(
+                        f"The given unit prefix {unit} does not " "have aliases, passing it as is"
+                    )
+                    prefix = orig_unit[: len(unit)]
 
                 return prefix + new_unit
             else:
                 return new_unit
 
     # If we conclude the loop without returning, it means the unit doesn't have aliases
-    LGR.warning(f'The given unit {orig_unit} does not have aliases, '
-                f'passing it as is')
+    LGR.warning(f"The given unit {orig_unit} does not have aliases, " f"passing it as is")
     return orig_unit
 
 
-def use_heuristic(heur_file, sub, ses, filename, outdir, take='', record_label=''):
+def use_heuristic(heur_file, sub, ses, filename, outdir, take="", record_label=""):
     """
     Import and use the heuristic specified by the user to rename the file.
 
@@ -133,47 +135,55 @@ def use_heuristic(heur_file, sub, ses, filename, outdir, take='', record_label='
     utils.check_file_exists(heur_file)
 
     # Initialise a dictionary of bids_keys that has already "recording"
-    bids_keys = {'sub': '', 'ses': '', 'task': '', 'acq': '', 'ce': '',
-                 'dir': '', 'rec': '', 'run': '', 'recording': record_label}
+    bids_keys = {
+        "sub": "",
+        "ses": "",
+        "task": "",
+        "acq": "",
+        "ce": "",
+        "dir": "",
+        "rec": "",
+        "run": "",
+        "recording": record_label,
+    }
 
     # Start filling bids_keys dictionary and path with subject and session
-    if sub.startswith('sub-'):
-        bids_keys['sub'] = sub[4:]
+    if sub.startswith("sub-"):
+        bids_keys["sub"] = sub[4:]
         fldr = os.path.join(outdir, sub)
     else:
-        bids_keys['sub'] = sub
-        fldr = os.path.join(outdir, f'sub-{sub}')
+        bids_keys["sub"] = sub
+        fldr = os.path.join(outdir, f"sub-{sub}")
 
     if ses:
-        if ses.startswith('ses-'):
-            bids_keys['ses'] = ses[4:]
+        if ses.startswith("ses-"):
+            bids_keys["ses"] = ses[4:]
             fldr = os.path.join(fldr, ses)
         else:
-            bids_keys['ses'] = ses
-            fldr = os.path.join(fldr, f'ses-{ses}')
+            bids_keys["ses"] = ses
+            fldr = os.path.join(fldr, f"ses-{ses}")
 
     # Load heuristic and use it to fill dictionary
     heur = utils.load_heuristic(heur_file)
     bids_keys.update(heur.heur(Path(filename).stem, take))
 
     # If bids_keys['task'] is still empty, stop the program
-    if not bids_keys['task']:
-        LGR.warning(f'The heuristic {heur_file} could not deal with'
-                    f'{Path(filename).stem}')
+    if not bids_keys["task"]:
+        LGR.warning(f"The heuristic {heur_file} could not deal with" f"{Path(filename).stem}")
         raise KeyError('No "task" attribute found')
 
     # Compose name by looping in the bids_keys dictionary
     # and adding nonempty keys
-    name = ''
+    name = ""
     for key in bids_keys:
-        if bids_keys[key] != '':
-            name = f'{name}{key}-{bids_keys[key]}_'
+        if bids_keys[key] != "":
+            name = f"{name}{key}-{bids_keys[key]}_"
 
     # Finish path, create it, add filename, export
-    fldr = os.path.join(fldr, 'func')
+    fldr = os.path.join(fldr, "func")
     os.makedirs(fldr, exist_ok=True)
 
-    heurpath = os.path.join(fldr, f'{name}physio')
+    heurpath = os.path.join(fldr, f"{name}physio")
 
     return heurpath
 
@@ -195,43 +205,44 @@ def participants_file(outdir, yml, sub):
         Subject ID.
 
     """
-    LGR.info('Updating participants.tsv ...')
-    file_path = os.path.join(outdir, 'participants.tsv')
+    LGR.info("Updating participants.tsv ...")
+    file_path = os.path.join(outdir, "participants.tsv")
     if not os.path.exists(file_path):
-        LGR.warning('phys2bids could not find participants.tsv')
+        LGR.warning("phys2bids could not find participants.tsv")
         # Read yaml info if file exists
-        if '.yml' in yml and os.path.exists(yml):
-            LGR.info('Using yaml data to populate participants.tsv')
+        if ".yml" in yml and os.path.exists(yml):
+            LGR.info("Using yaml data to populate participants.tsv")
             with open(yml) as f:
                 yaml_data = yaml.load(f, Loader=yaml.FullLoader)
-            p_id = f'sub-{sub}'
-            p_age = yaml_data['participant']['age']
-            p_sex = yaml_data['participant']['sex']
-            p_handedness = yaml_data['participant']['handedness']
+            p_id = f"sub-{sub}"
+            p_age = yaml_data["participant"]["age"]
+            p_sex = yaml_data["participant"]["sex"]
+            p_handedness = yaml_data["participant"]["handedness"]
         else:
-            LGR.info('No yaml file was provided. Using phys2bids data to '
-                     'populate participants.tsv')
+            LGR.info(
+                "No yaml file was provided. Using phys2bids data to " "populate participants.tsv"
+            )
             # Fill in with data from phys2bids
-            p_id = f'sub-{sub}'
-            p_age = 'n/a'
-            p_sex = 'n/a'
-            p_handedness = 'n/a'
+            p_id = f"sub-{sub}"
+            p_age = "n/a"
+            p_sex = "n/a"
+            p_handedness = "n/a"
 
         # Write to participants.tsv file
-        header = ['participant_id', 'age', 'sex', 'handedness']
+        header = ["participant_id", "age", "sex", "handedness"]
         utils.append_list_as_row(file_path, header)
 
         participants_data = [p_id, p_age, p_sex, p_handedness]
         utils.append_list_as_row(file_path, participants_data)
 
     else:  # If participants.tsv exists only update when subject is not there
-        LGR.info('phys2bids found participants.tsv. Updating if needed...')
+        LGR.info("phys2bids found participants.tsv. Updating if needed...")
         # Find participant_id column in header
-        pf = open(file_path, 'r')
+        pf = open(file_path, "r")
         header = pf.readline().split("\t")
         header_length = len(header)
         pf.close()
-        p_id_idx = header.index('participant_id')
+        p_id_idx = header.index("participant_id")
 
         # Check if subject is already in the file
         sub_exists = False
@@ -262,13 +273,17 @@ def dataset_description_file(outdir):
 
     """
     # dictionary that will be written for the basic dataset description version
-    data_dict = {"Name": os.path.splitext(os.path.basename(outdir))[0],
-                 "BIDSVersion": "1.4.0", "DatasetType": "raw"}
-    file_path = os.path.join(outdir, 'dataset_description.json')
+    data_dict = {
+        "Name": os.path.splitext(os.path.basename(outdir))[0],
+        "BIDSVersion": "1.4.0",
+        "DatasetType": "raw",
+    }
+    file_path = os.path.join(outdir, "dataset_description.json")
     # check if dataset_description.json exists, if it doesn't create it
     if not os.path.exists(file_path):
-        LGR.warning('phys2bids could not find dataset_description.json,'
-                    'generating it with provided info')
+        LGR.warning(
+            "phys2bids could not find dataset_description.json," "generating it with provided info"
+        )
         utils.write_json(file_path, data_dict)
 
 
@@ -284,9 +299,11 @@ def readme_file(outdir):
         Full path to the output directory.
 
     """
-    file_path = os.path.join(outdir, 'README')
+    file_path = os.path.join(outdir, "README")
     if not os.path.exists(file_path):
-        text = 'Empty README, please fill in describing the dataset in more detail.'
-        LGR.warning('phys2bids could not find README,'
-                    'generating it EMPTY, please fill in the necessary info')
-        utils.write_file(file_path, '', text)
+        text = "Empty README, please fill in describing the dataset in more detail."
+        LGR.warning(
+            "phys2bids could not find README,"
+            "generating it EMPTY, please fill in the necessary info"
+        )
+        utils.write_file(file_path, "", text)

--- a/phys2bids/cli/run.py
+++ b/phys2bids/cli/run.py
@@ -152,7 +152,9 @@ def _get_parser():
     return parser
 
 
-if __name__ == '__main__':
-    raise RuntimeError('phys2bids/cli/run.py should not be run directly;\n'
-                       'Please `pip install` phys2bids and use the '
-                       '`phys2bids` command')
+if __name__ == "__main__":
+    raise RuntimeError(
+        "phys2bids/cli/run.py should not be run directly;\n"
+        "Please `pip install` phys2bids and use the "
+        "`phys2bids` command"
+    )

--- a/phys2bids/cli/run.py
+++ b/phys2bids/cli/run.py
@@ -22,130 +22,174 @@ def _get_parser():
     """
     parser = argparse.ArgumentParser()
     optional = parser._action_groups.pop()
-    required = parser.add_argument_group('Required Argument:')
-    required.add_argument('-in', '--input-file',
-                          dest='filename',
-                          type=str,
-                          help='The name of the file containing physiological '
-                               'data, with or without extension.',
-                          required=True)
-    optional.add_argument('-info', '--info',
-                          dest='info',
-                          action='store_true',
-                          help='Only output info about the file, don\'t process. '
-                               'Default is to process.',
-                          default=False)
-    optional.add_argument('-indir', '--input-dir',
-                          dest='indir',
-                          type=str,
-                          help='Folder containing input. '
-                               'Default is current folder.',
-                          default='.')
-    optional.add_argument('-outdir', '--output-dir',
-                          dest='outdir',
-                          type=str,
-                          help='Folder where output should be placed. '
-                               'Default is current folder. '
-                               'If \"-heur\" is used, it\'ll become '
-                               'the site folder. Requires \"-sub\". '
-                               'Optional to specify \"-ses\".',
-                          default='.')
-    optional.add_argument('-heur', '--heuristic',
-                          dest='heur_file',
-                          type=str,
-                          help='File containing heuristic, with or without '
-                               'extension. This file is needed in order to '
-                               'convert your input file to BIDS format! '
-                               'If no path is specified, it assumes the file is '
-                               'in the current folder. Edit the heur_ex.py file in '
-                               'heuristics folder.',
-                          default=None)
-    optional.add_argument('-sub', '--subject',
-                          dest='sub',
-                          type=str,
-                          help='Specify alongside \"-heur\". Code of '
-                               'subject to process.',
-                          default=None)
-    optional.add_argument('-ses', '--session',
-                          dest='ses',
-                          type=str,
-                          help='Specify alongside \"-heur\". Code of '
-                               'session to process.',
-                          default=None)
-    optional.add_argument('-chtrig', '--channel-trigger',
-                          dest='chtrig',
-                          type=int,
-                          help='The column number of the trigger channel. '
-                               'Channel numbering starts with 1. '
-                               'Default is 0. If chtrig is left as zero phys2bids will '
-                               'perform an automatic trigger channel search by channel names.',
-                          default=0)
-    optional.add_argument('-chsel', '--channel-selection',
-                          dest='chsel',
-                          nargs='*',
-                          type=int,
-                          help='The column numbers of  the channels to process. '
-                               'Default is to process all channels.',
-                          default=None)
-    optional.add_argument('-ntp', '--numtps',
-                          dest='num_timepoints_expected',
-                          nargs='*',
-                          type=int,
-                          help='Number of expected trigger timepoints (TRs). '
-                               'Default is None. Note: the estimation of beginning of '
-                               'neuroimaging acquisition cannot take place with this default. '
-                               'If you\'re running phys2bids on a multi-run recording, '
-                               'give a list of each expected ntp for each run.',
-                          default=None)
-    optional.add_argument('-tr', '--tr',
-                          dest='tr',
-                          nargs='*',
-                          type=float,
-                          help='TR of sequence in seconds. '
-                               'If you\'re running phys2bids on a multi-run recording, '
-                               'you can give a list of each expected ntp for each run, '
-                               'or just one TR if it is consistent throughout the session.',
-                          default=None)
-    optional.add_argument('-thr', '--threshold',
-                          dest='thr',
-                          type=float,
-                          help='Threshold to use for trigger detection. '
-                               'If "ntp" and "TR" are specified, phys2bids '
-                               'automatically computes a threshold to detect '
-                               'the triggers. Use this parameter to set it manually. '
-                               'This parameter is necessary for multi-run recordings. ',
-                          default=None)
-    optional.add_argument('-pad', '--padding',
-                          dest='pad',
-                          type=float,
-                          help='Padding in seconds used around a single run '
-                               'when separating multi-run session files. '
-                               'Default is 9 seconds.',
-                          default=9)
-    optional.add_argument('-chnames', '--channel-names',
-                          dest='ch_name',
-                          nargs='*',
-                          type=str,
-                          help='Column header (for json file output).',
-                          default=[])
-    optional.add_argument('-yml', '--participant-yml',
-                          dest='yml',
-                          type=str,
-                          help='full path to file with info needed to generate '
-                               'participant.tsv file ',
-                          default='')
-    optional.add_argument('-debug', '--debug',
-                          dest='debug',
-                          action='store_true',
-                          help='Only print debugging info to log file. Default is False.',
-                          default=False)
-    optional.add_argument('-quiet', '--quiet',
-                          dest='quiet',
-                          action='store_true',
-                          help='Only print warnings to log file. Default is False.',
-                          default=False)
-    optional.add_argument('-v', '--version', action='version',
-                          version=('%(prog)s ' + __version__))
+    required = parser.add_argument_group("Required Argument:")
+    required.add_argument(
+        "-in",
+        "--input-file",
+        dest="filename",
+        type=str,
+        help="The name of the file containing physiological " "data, with or without extension.",
+        required=True,
+    )
+    optional.add_argument(
+        "-info",
+        "--info",
+        dest="info",
+        action="store_true",
+        help="Only output info about the file, don't process. " "Default is to process.",
+        default=False,
+    )
+    optional.add_argument(
+        "-indir",
+        "--input-dir",
+        dest="indir",
+        type=str,
+        help="Folder containing input. " "Default is current folder.",
+        default=".",
+    )
+    optional.add_argument(
+        "-outdir",
+        "--output-dir",
+        dest="outdir",
+        type=str,
+        help="Folder where output should be placed. "
+        "Default is current folder. "
+        'If "-heur" is used, it\'ll become '
+        'the site folder. Requires "-sub". '
+        'Optional to specify "-ses".',
+        default=".",
+    )
+    optional.add_argument(
+        "-heur",
+        "--heuristic",
+        dest="heur_file",
+        type=str,
+        help="File containing heuristic, with or without "
+        "extension. This file is needed in order to "
+        "convert your input file to BIDS format! "
+        "If no path is specified, it assumes the file is "
+        "in the current folder. Edit the heur_ex.py file in "
+        "heuristics folder.",
+        default=None,
+    )
+    optional.add_argument(
+        "-sub",
+        "--subject",
+        dest="sub",
+        type=str,
+        help='Specify alongside "-heur". Code of ' "subject to process.",
+        default=None,
+    )
+    optional.add_argument(
+        "-ses",
+        "--session",
+        dest="ses",
+        type=str,
+        help='Specify alongside "-heur". Code of ' "session to process.",
+        default=None,
+    )
+    optional.add_argument(
+        "-chtrig",
+        "--channel-trigger",
+        dest="chtrig",
+        type=int,
+        help="The column number of the trigger channel. "
+        "Channel numbering starts with 1. "
+        "Default is 0. If chtrig is left as zero phys2bids will "
+        "perform an automatic trigger channel search by channel names.",
+        default=0,
+    )
+    optional.add_argument(
+        "-chsel",
+        "--channel-selection",
+        dest="chsel",
+        nargs="*",
+        type=int,
+        help="The column numbers of  the channels to process. "
+        "Default is to process all channels.",
+        default=None,
+    )
+    optional.add_argument(
+        "-ntp",
+        "--numtps",
+        dest="num_timepoints_expected",
+        nargs="*",
+        type=int,
+        help="Number of expected trigger timepoints (TRs). "
+        "Default is None. Note: the estimation of beginning of "
+        "neuroimaging acquisition cannot take place with this default. "
+        "If you're running phys2bids on a multi-run recording, "
+        "give a list of each expected ntp for each run.",
+        default=None,
+    )
+    optional.add_argument(
+        "-tr",
+        "--tr",
+        dest="tr",
+        nargs="*",
+        type=float,
+        help="TR of sequence in seconds. "
+        "If you're running phys2bids on a multi-run recording, "
+        "you can give a list of each expected ntp for each run, "
+        "or just one TR if it is consistent throughout the session.",
+        default=None,
+    )
+    optional.add_argument(
+        "-thr",
+        "--threshold",
+        dest="thr",
+        type=float,
+        help="Threshold to use for trigger detection. "
+        'If "ntp" and "TR" are specified, phys2bids '
+        "automatically computes a threshold to detect "
+        "the triggers. Use this parameter to set it manually. "
+        "This parameter is necessary for multi-run recordings. ",
+        default=None,
+    )
+    optional.add_argument(
+        "-pad",
+        "--padding",
+        dest="pad",
+        type=float,
+        help="Padding in seconds used around a single run "
+        "when separating multi-run session files. "
+        "Default is 9 seconds.",
+        default=9,
+    )
+    optional.add_argument(
+        "-chnames",
+        "--channel-names",
+        dest="ch_name",
+        nargs="*",
+        type=str,
+        help="Column header (for json file output).",
+        default=[],
+    )
+    optional.add_argument(
+        "-yml",
+        "--participant-yml",
+        dest="yml",
+        type=str,
+        help="full path to file with info needed to generate " "participant.tsv file ",
+        default="",
+    )
+    optional.add_argument(
+        "-debug",
+        "--debug",
+        dest="debug",
+        action="store_true",
+        help="Only print debugging info to log file. Default is False.",
+        default=False,
+    )
+    optional.add_argument(
+        "-quiet",
+        "--quiet",
+        dest="quiet",
+        action="store_true",
+        help="Only print warnings to log file. Default is False.",
+        default=False,
+    )
+    optional.add_argument("-v", "--version", action="version", version=("%(prog)s " + __version__))
 
     parser._action_groups.append(optional)
 

--- a/phys2bids/due.py
+++ b/phys2bids/due.py
@@ -17,9 +17,9 @@ License:    BSD-2
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### #
 """
 
-from builtins import str
-from builtins import object
-__version__ = '0.0.5'
+from builtins import object, str
+
+__version__ = "0.0.5"
 
 
 class InactiveDueCreditCollector(object):
@@ -31,15 +31,17 @@ class InactiveDueCreditCollector(object):
 
     def dcite(self, *args, **kwargs):
         """If I could cite I would."""
+
         def nondecorating_decorator(func):
             return func
+
         return nondecorating_decorator
 
     cite = load = add = _donothing
 
     def __repr__(self):
         """Return class function."""
-        return self.__class__.__name__ + '()'
+        return self.__class__.__name__ + "()"
 
 
 def _donothing_func(*args, **kwargs):
@@ -48,16 +50,19 @@ def _donothing_func(*args, **kwargs):
 
 
 try:
-    from duecredit import due, BibTeX, Doi, Url
-    if 'due' in locals() and not hasattr(due, 'cite'):
-        raise RuntimeError(
-            "Imported due lacks .cite. DueCredit is now disabled")
+    from duecredit import BibTeX, Doi, Url, due
+
+    if "due" in locals() and not hasattr(due, "cite"):
+        raise RuntimeError("Imported due lacks .cite. DueCredit is now disabled")
 except Exception as e:
-    if type(e).__name__ != 'ImportError':
+    if type(e).__name__ != "ImportError":
         import logging
+
         logging.getLogger("duecredit").error(
             'Module `duecredit` not successfully imported due to "%s". '
-            'Package functionality unaffected.', str(e))
+            "Package functionality unaffected.",
+            str(e),
+        )
 
     # Initiate due stub
     due = InactiveDueCreditCollector()

--- a/phys2bids/heuristics/heur_euskalibur.py
+++ b/phys2bids/heuristics/heur_euskalibur.py
@@ -1,7 +1,7 @@
 import fnmatch
 
 
-def heur(physinfo, take=''):
+def heur(physinfo, take=""):
     """
     Set of if .. elif statements to fill BIDS names.
 
@@ -56,31 +56,31 @@ def heur(physinfo, take=''):
     # ##  See example below          ## #
     # ################################# #
 
-    if physinfo == 'origfilename1':
-        info['task'] = 'newname1'
-    elif physinfo == 'origfilename2':
-        info['task'] = 'newname2'
-        info['run'] = 'runnum'
-    elif physinfo == 'BH4':
-        info['task'] = 'breathhold'
-    elif fnmatch.fnmatchcase(physinfo, 'MOTOR?'):
-        info['task'] = 'motor'
-    elif fnmatch.fnmatchcase(physinfo, 'LOCALIZER?'):
-        info['task'] = 'pinel'
-    elif fnmatch.fnmatchcase(physinfo, 'SIMON?'):
-        info['task'] = 'simon'
-    elif physinfo == 'RS1':
-        info['task'] = 'rest'
-        info['run'] = '01'
-    elif physinfo == 'RS2':
-        info['task'] = 'rest'
-        info['run'] = '02'
-    elif physinfo == 'RS3':
-        info['task'] = 'rest'
-        info['run'] = '03'
-    elif physinfo == 'RS4':
-        info['task'] = 'rest'
-        info['run'] = '04'
+    if physinfo == "origfilename1":
+        info["task"] = "newname1"
+    elif physinfo == "origfilename2":
+        info["task"] = "newname2"
+        info["run"] = "runnum"
+    elif physinfo == "BH4":
+        info["task"] = "breathhold"
+    elif fnmatch.fnmatchcase(physinfo, "MOTOR?"):
+        info["task"] = "motor"
+    elif fnmatch.fnmatchcase(physinfo, "LOCALIZER?"):
+        info["task"] = "pinel"
+    elif fnmatch.fnmatchcase(physinfo, "SIMON?"):
+        info["task"] = "simon"
+    elif physinfo == "RS1":
+        info["task"] = "rest"
+        info["run"] = "01"
+    elif physinfo == "RS2":
+        info["task"] = "rest"
+        info["run"] = "02"
+    elif physinfo == "RS3":
+        info["task"] = "rest"
+        info["run"] = "03"
+    elif physinfo == "RS4":
+        info["task"] = "rest"
+        info["run"] = "04"
 
     # ############################## #
     # ## Don't modify below this! ## #

--- a/phys2bids/heuristics/heur_test_acq.py
+++ b/phys2bids/heuristics/heur_test_acq.py
@@ -1,7 +1,7 @@
 import fnmatch
 
 
-def heur(physinfo, take=''):
+def heur(physinfo, take=""):
     """
     Set of if .. elif statements to fill BIDS names.
 
@@ -56,14 +56,14 @@ def heur(physinfo, take=''):
     # ##  See example below          ## #
     # ################################# #
 
-    if fnmatch.fnmatchcase(physinfo, '*samefreq*'):
-        info['task'] = 'test'
-        info['run'] = '01'
-        info['rec'] = 'biopac'
-    elif physinfo == 'Example':
-        info['task'] = 'rest'
-        info['run'] = '01'
-        info['acq'] = 'resp'
+    if fnmatch.fnmatchcase(physinfo, "*samefreq*"):
+        info["task"] = "test"
+        info["run"] = "01"
+        info["rec"] = "biopac"
+    elif physinfo == "Example":
+        info["task"] = "rest"
+        info["run"] = "01"
+        info["acq"] = "resp"
 
     # ############################## #
     # ## Don't modify below this! ## #

--- a/phys2bids/heuristics/heur_test_multifreq.py
+++ b/phys2bids/heuristics/heur_test_multifreq.py
@@ -1,7 +1,7 @@
 import fnmatch
 
 
-def heur(physinfo, take=''):
+def heur(physinfo, take=""):
     """
     Set of if .. elif statements to fill BIDS names.
 
@@ -56,14 +56,14 @@ def heur(physinfo, take=''):
     # ##  See example below          ## #
     # ################################# #
 
-    if fnmatch.fnmatchcase(physinfo, '*onescan*'):
-        info['task'] = 'test'
-        info['run'] = '01'
-        info['rec'] = 'biopac'
-    elif physinfo == 'Example':
-        info['task'] = 'rest'
-        info['run'] = '01'
-        info['acq'] = 'resp'
+    if fnmatch.fnmatchcase(physinfo, "*onescan*"):
+        info["task"] = "test"
+        info["run"] = "01"
+        info["rec"] = "biopac"
+    elif physinfo == "Example":
+        info["task"] = "rest"
+        info["run"] = "01"
+        info["acq"] = "resp"
 
     # ############################## #
     # ## Don't modify below this! ## #

--- a/phys2bids/heuristics/heur_tutorial.py
+++ b/phys2bids/heuristics/heur_tutorial.py
@@ -1,7 +1,7 @@
 import fnmatch
 
 
-def heur(physinfo, take=''):
+def heur(physinfo, take=""):
     """
     Set of if .. elif statements to fill BIDS names.
 
@@ -56,14 +56,14 @@ def heur(physinfo, take=''):
     # ##  See example below          ## #
     # ################################# #
 
-    if fnmatch.fnmatchcase(physinfo, '*tutorial*'):
-        info['task'] = 'test'
-        info['run'] = '01'
-        info['rec'] = 'labchart'
-    elif physinfo == 'Example':
-        info['task'] = 'rest'
-        info['run'] = '01'
-        info['acq'] = 'resp'
+    if fnmatch.fnmatchcase(physinfo, "*tutorial*"):
+        info["task"] = "test"
+        info["run"] = "01"
+        info["rec"] = "labchart"
+    elif physinfo == "Example":
+        info["task"] = "rest"
+        info["run"] = "01"
+        info["acq"] = "resp"
 
     # ############################## #
     # ## Don't modify below this! ## #

--- a/phys2bids/io.py
+++ b/phys2bids/io.py
@@ -13,10 +13,10 @@ from phys2bids.physio_obj import BlueprintInput
 
 LGR = logging.getLogger(__name__)
 OPEN_ISSUE = (
-    'The file you are trying to convert might not be supported by phys2bids yet. '
-    'Please open an issue on GitHub '
-    '(https://github.com/physiopy/phys2bids/issues/new/choose) '
-    'so that we can improve file support!'
+    "The file you are trying to convert might not be supported by phys2bids yet. "
+    "Please open an issue on GitHub "
+    "(https://github.com/physiopy/phys2bids/issues/new/choose) "
+    "so that we can improve file support!"
 )
 
 
@@ -43,7 +43,7 @@ def check_multifreq(timeseries, freq, start=0, endat=None):
     multifreq_freq : list of floats
         new list with the real frequency of the channels
     """
-    LGR.info('Checking if frequencies are different across channels')
+    LGR.info("Checking if frequencies are different across channels")
     multifreq_freq = deepcopy(freq)
     multifreq_timeseries = deepcopy(timeseries)
 
@@ -102,52 +102,67 @@ def generate_blueprint(timeseries, chtrig, interval, orig_units, orig_names):
     --------
     physio_obj.BlueprintInput
     """
-    if interval[-1] not in ['min', 'sec', 'µsec', 'msec', 'MHz', 'kHz', 'Hz', 'hr', 'min', 's',
-                            'ms', 'µs']:
-        raise AttributeError(f'Interval unit "{interval[-1]}" is not in a '
-                             'valid frequency or time unit format, this probably '
-                             'means your file is not in min, sec, msec, µsec, hr, min, s, ms, µs, '
-                             'Mhz, KHz or Hz')
+    if interval[-1] not in [
+        "min",
+        "sec",
+        "µsec",
+        "msec",
+        "MHz",
+        "kHz",
+        "Hz",
+        "hr",
+        "min",
+        "s",
+        "ms",
+        "µs",
+    ]:
+        raise AttributeError(
+            f'Interval unit "{interval[-1]}" is not in a '
+            "valid frequency or time unit format, this probably "
+            "means your file is not in min, sec, msec, µsec, hr, min, s, ms, µs, "
+            "Mhz, KHz or Hz"
+        )
     # Check if the header is in frequency or sampling interval
     if 'Hz' in interval[-1]:
         LGR.info('Retrieving frequency from file header, calculating sample interval, '
                  'and standardizing to Hz if needed')
         freq = float(interval[0])
         freq_unit = interval[-1]
-        if freq_unit == 'MHz':
+        if freq_unit == "MHz":
             freq = freq * (1000000)
-        elif freq_unit == 'kHz':
+        elif freq_unit == "kHz":
             freq = freq * 1000
         interval[0] = 1 / freq
         freq = [freq] * len(timeseries)
     else:
         # check if interval is in seconds, if not change the units to seconds and
         # calculate frequency
-        if interval[-1] not in ('s', 'sec'):
-            LGR.warning('Sampling interval not expressed in seconds. '
-                        'Converting its value and unit.')
-            if interval[-1] == 'min':
+        if interval[-1] not in ("s", "sec"):
+            LGR.warning(
+                "Sampling interval not expressed in seconds. " "Converting its value and unit."
+            )
+            if interval[-1] == "min":
                 interval[0] = float(interval[0]) * 60
-            elif interval[-1] == 'msec':
+            elif interval[-1] == "msec":
                 interval[0] = float(interval[0]) / 1000
-            elif interval[-1] == 'µsec':
+            elif interval[-1] == "µsec":
                 interval[0] = float(interval[0]) / 1000000
-            elif interval[-1] == 'hr':
+            elif interval[-1] == "hr":
                 interval[0] = float(interval[0]) * 3600
-            elif interval[-1] == 'ms':
+            elif interval[-1] == "ms":
                 interval[0] = float(interval[0]) / 1000
-            elif interval[-1] == 'µs':
+            elif interval[-1] == "µs":
                 interval[0] = float(interval[0]) / 1000000
-            interval[-1] = 's'
+            interval[-1] = "s"
         else:
             interval[0] = float(interval[0])
         # get frequency
         freq = [1 / interval[0]] * len(timeseries)
     # reorder channels names
-    names = ['time', ]
+    names = ['time']
     names = names + orig_names
     # reorder channels units
-    units = ['s', ]
+    units = ['s']
     units = units + orig_units
     # Check if the file has a time channel, otherwise create it.
     # As the "time" doesn't have a column header, if the number of header names
@@ -155,8 +170,10 @@ def generate_blueprint(timeseries, chtrig, interval, orig_units, orig_names):
     # ...otherwise, create the time channel
     if not (len(orig_names) < len(timeseries)):
         duration = (timeseries[0].shape[0] + 1) * interval[0]
-        t_ch = np.ogrid[0:duration:interval[0]][:-1]  # create time channel
-        timeseries = [t_ch, ] + timeseries
+        t_ch = np.ogrid[0 : duration : interval[0]][:-1]  # create time channel
+        timeseries = [
+            t_ch,
+        ] + timeseries
         freq = [max(freq)] + freq
     timeseries, freq = check_multifreq(timeseries, freq)
     return BlueprintInput(timeseries, freq, names, units, chtrig)
@@ -181,11 +198,11 @@ def read_header_and_channels(filename):
     """
     header = []
     # Read in the header until it's numbers
-    with open(filename, 'r') as f:
+    with open(filename, "r") as f:
         for n, line in enumerate(f):
-            line = line.rstrip('\n').split('\t')
-            if line[-1] == '':
-                line.remove('')
+            line = line.rstrip("\n").split("\t")
+            if line[-1] == "":
+                line.remove("")
             try:
                 float(line[0])
                 break
@@ -193,14 +210,14 @@ def read_header_and_channels(filename):
                 header.append(line)
                 continue
     # Read in the rest paying attention to possible differences
-    if 'Interval=' in header[0]:
+    if "Interval=" in header[0]:
         # Not specifying delimiters will ignore comments
         channel_list = np.genfromtxt(filename, skip_header=n)
-    elif 'acq' in header[0][0]:
+    elif "acq" in header[0][0]:
         # Specifying delimiters will avoid missing values in the files
-        channel_list = np.genfromtxt(filename, skip_header=n, delimiter='\t')
+        channel_list = np.genfromtxt(filename, skip_header=n, delimiter="\t")
         # Remove extra (empty?) columns, if present
-        ch_number = int(header[2][0].split(' ')[0])
+        ch_number = int(header[2][0].split(" ")[0])
         channel_list = channel_list[:, :ch_number]
         # Set all remaining NaNs to 0
         channel_list = np.nan_to_num(channel_list)
@@ -244,19 +261,19 @@ def extract_header_items(header):
     """
     # check header is not empty and detect if it is in labchart or Acqknoledge format
     if len(header) == 0:
-        raise NotImplementedError('Files without header are not supported yet')
-    elif 'Interval=' in header[0]:
-        LGR.info('phys2bids detected that your file is in Labchart format')
+        raise NotImplementedError("Files without header are not supported yet")
+    elif "Interval=" in header[0]:
+        LGR.info("phys2bids detected that your file is in Labchart format")
 
         interval = None
         orig_names = None
         range_list = None
         for line in header:
-            if 'Interval=' in line:
+            if "Interval=" in line:
                 interval = line[1].split(" ")
-            if 'ChannelTitle=' in line:
+            if "ChannelTitle=" in line:
                 orig_names = line[1:]
-            if 'Range=' in line:
+            if "Range=" in line:
                 range_list = line[1:]
 
         if None in [interval, orig_names, range_list]:
@@ -264,12 +281,12 @@ def extract_header_items(header):
 
         orig_units = []
         for item in range_list:
-            orig_units.append(item.split(' ')[1])
+            orig_units.append(item.split(" ")[1])
 
-    elif 'acq' in header[0][0]:
-        LGR.info('phys2bids detected that your file is in AcqKnowledge format')
+    elif "acq" in header[0][0]:
+        LGR.info("phys2bids detected that your file is in AcqKnowledge format")
         interval = header[1][0].split()
-        interval[-1] = interval[-1].split('/')[0]
+        interval[-1] = interval[-1].split("/")[0]
         # get units and names
         orig_units = []
         orig_names = []
@@ -337,17 +354,18 @@ def load_acq(filename, chtrig=0):
     physio_obj.BlueprintInput
     """
     from bioread import read_file
+
     with warnings.catch_warnings():
-        warnings.filterwarnings('ignore', category=DeprecationWarning)
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
         data = read_file(filename).channels
 
-    freq = [data[0].samples_per_second, ]
-    timeseries = [data[0].time_index, ]
-    units = ['s', ]
-    names = ['time', ]
+    freq = [data[0].samples_per_second]
+    timeseries = [data[0].time_index]
+    units = ['s']
+    names = ['time']
 
     for k, ch in enumerate(data):
-        LGR.info(f'{k:02d}. {ch}')
+        LGR.info(f"{k:02d}. {ch}")
         timeseries.append(ch.data)
         freq.append(ch.samples_per_second)
         units.append(ch.units)
@@ -384,40 +402,49 @@ def load_mat(filename, chtrig=0):
     """
     # Load MATLAB file into dictionary.
     from pymatreader import read_mat
+
     mat_dict = read_mat(filename)
-    if '__header__' in mat_dict:
-        orig_names = list(mat_dict['labels'])
-        orig_units = list(mat_dict['units'])
-        interval = [mat_dict['isi'], mat_dict['isi_units']]
-        channel_list = mat_dict['data']
+    if "__header__" in mat_dict:
+        orig_names = list(mat_dict["labels"])
+        orig_units = list(mat_dict["units"])
+        interval = [mat_dict["isi"], mat_dict["isi_units"]]
+        channel_list = mat_dict["data"]
         channel_list = [ch for ch in channel_list.T]
         return generate_blueprint(channel_list, chtrig, interval, orig_units, orig_names)
     else:
         # Convert data into 1d numpy array for easier indexing.
-        data = np.squeeze(np.asarray(mat_dict['data']))
+        data = np.squeeze(np.asarray(mat_dict["data"]))
 
         # Extract number of channels and tick rate.
-        n_channels = len(mat_dict['titles'])
-        t_freq = mat_dict['tickrate']
+        n_channels = len(mat_dict["titles"])
+        t_freq = mat_dict["tickrate"]
 
         # Stores MATLAB data into lists.
         timeseries = []
-        freq = [t_freq, ]
-        units = ['s', ]
-        names = ['time', ]
+        freq = [
+            t_freq,
+        ]
+        units = [
+            "s",
+        ]
+        names = [
+            "time",
+        ]
 
         for ch in range(n_channels):
-            units.append(mat_dict['unittext'][int(mat_dict['unittextmap'][ch] - 1)].strip())
-            names.append(mat_dict['titles'][ch].strip())
-            freq.append(mat_dict['samplerate'][ch])
-            idx_start = int(mat_dict['datastart'][ch])
-            idx_end = int(mat_dict['dataend'][ch])
+            units.append(mat_dict["unittext"][int(mat_dict["unittextmap"][ch] - 1)].strip())
+            names.append(mat_dict["titles"][ch].strip())
+            freq.append(mat_dict["samplerate"][ch])
+            idx_start = int(mat_dict["datastart"][ch])
+            idx_end = int(mat_dict["dataend"][ch])
             timeseries.append(data[idx_start:idx_end])
         # Calculate duration based on frequency and create time channel.
         interval = 1 / t_freq
         duration = (timeseries[0].shape[0] + 1) * interval
         t_ch = np.ogrid[0:duration:interval][:-1]
-        timeseries = [t_ch, ] + timeseries
+        timeseries = [
+            t_ch,
+        ] + timeseries
         return BlueprintInput(timeseries, freq, names, units, chtrig)
 
 

--- a/phys2bids/io.py
+++ b/phys2bids/io.py
@@ -123,9 +123,11 @@ def generate_blueprint(timeseries, chtrig, interval, orig_units, orig_names):
             "Mhz, KHz or Hz"
         )
     # Check if the header is in frequency or sampling interval
-    if 'Hz' in interval[-1]:
-        LGR.info('Retrieving frequency from file header, calculating sample interval, '
-                 'and standardizing to Hz if needed')
+    if "Hz" in interval[-1]:
+        LGR.info(
+            "Retrieving frequency from file header, calculating sample interval, "
+            "and standardizing to Hz if needed"
+        )
         freq = float(interval[0])
         freq_unit = interval[-1]
         if freq_unit == "MHz":
@@ -159,10 +161,10 @@ def generate_blueprint(timeseries, chtrig, interval, orig_units, orig_names):
         # get frequency
         freq = [1 / interval[0]] * len(timeseries)
     # reorder channels names
-    names = ['time']
+    names = ["time"]
     names = names + orig_names
     # reorder channels units
-    units = ['s']
+    units = ["s"]
     units = units + orig_units
     # Check if the file has a time channel, otherwise create it.
     # As the "time" doesn't have a column header, if the number of header names
@@ -361,8 +363,8 @@ def load_acq(filename, chtrig=0):
 
     freq = [data[0].samples_per_second]
     timeseries = [data[0].time_index]
-    units = ['s']
-    names = ['time']
+    units = ["s"]
+    names = ["time"]
 
     for k, ch in enumerate(data):
         LGR.info(f"{k:02d}. {ch}")
@@ -488,19 +490,19 @@ def load_gep(filename):
     from pathlib import Path
 
     # Initiate lists of column names and units with time and trigger
-    names = ['time', 'trigger']
-    units = ['s', 'mV']  # Assuming recording units are mV...
+    names = ["time", "trigger"]
+    units = ["s", "mV"]  # Assuming recording units are mV...
 
     # Add column for file given by user
-    if 'PPGData' in filename:
+    if "PPGData" in filename:
         freq = [100, 100, 100]
-        names.append('cardiac')
-    elif 'RESPData' in filename:
+        names.append("cardiac")
+    elif "RESPData" in filename:
         freq = [25, 25, 25]
-        names.append('respiratory')
-    elif 'ECGData' in filename:
+        names.append("respiratory")
+    elif "ECGData" in filename:
         freq = [1000, 1000, 1000]
-        names.append('cardiac')
+        names.append("cardiac")
 
     # Load in user file data
     data = [np.loadtxt(filename)]
@@ -508,30 +510,29 @@ def load_gep(filename):
     # Calculate time in seconds for first input (starts from -30s)
     interval = 1 / freq[0]
     duration = data[0].shape[0] * interval
-    t_ch = np.ogrid[-30:duration - 30:interval]
+    t_ch = np.ogrid[-30 : duration - 30 : interval]
 
     # Find and add additional data files
     filename = Path(filename)
-    fnames = glob(os.path.join(filename.parent, f'*{filename.name[-24:-4]}.gep'))
+    fnames = glob(os.path.join(filename.parent, f"*{filename.name[-24:-4]}.gep"))
     fnames.remove(str(filename))  # Drop the original file
     if not len(fnames) == 0:
         for fname in fnames:
-            if 'PPGData' in fname:
+            if "PPGData" in fname:
                 freq.append(100)
-                names.append('cardiac')
+                names.append("cardiac")
                 data.append(np.loadtxt(fname))
-            elif 'RESPData' in fname:
+            elif "RESPData" in fname:
                 freq.append(25)
-                names.append('respiratory')
+                names.append("respiratory")
                 data.append(np.loadtxt(fname))
-            elif 'ECGData' in fname:
+            elif "ECGData" in fname:
                 freq.append(1000)
-                names.append('cardiac')
+                names.append("cardiac")
                 data.append(np.loadtxt(fname))
 
     # Create trigger channel
-    trigger = np.hstack((np.zeros(int(30 / interval)),
-                         np.ones(int((duration - 30) / interval))))
+    trigger = np.hstack((np.zeros(int(30 / interval)), np.ones(int((duration - 30) / interval))))
 
     # Create final list of timeseries
     timeseries = [t_ch, trigger]

--- a/phys2bids/phys2bids.py
+++ b/phys2bids/phys2bids.py
@@ -35,13 +35,13 @@ from shutil import copy as cp
 
 import numpy as np
 
-from phys2bids import utils, viz, _version, bids
+from phys2bids import _version, bids, utils, viz
 from phys2bids.cli.run import _get_parser
 from phys2bids.physio_obj import BlueprintOutput
 from phys2bids.slice4phys import slice4phys
 
 from . import __version__
-from .due import due, Doi
+from .due import Doi, due
 
 LGR = logging.getLogger(__name__)
 LGR.setLevel(logging.INFO)
@@ -75,17 +75,19 @@ def print_summary(filename, ntp_expected, ntp_found, samp_freq, time_offset, out
         File containing summary
     """
     start_time = -time_offset
-    summary = (f'\n------------------------------------------------\n'
-               f'Filename:            {filename}\n'
-               f'\n'
-               f'Timepoints expected: {ntp_expected}\n'
-               f'Timepoints found:    {ntp_found}\n'
-               f'Sampling Frequency:  {samp_freq} Hz\n'
-               f'Sampling started at: {start_time:.4f} s\n'
-               f'Tip: Time 0 is the time of first trigger\n'
-               f'------------------------------------------------\n')
+    summary = (
+        f"\n------------------------------------------------\n"
+        f"Filename:            {filename}\n"
+        f"\n"
+        f"Timepoints expected: {ntp_expected}\n"
+        f"Timepoints found:    {ntp_found}\n"
+        f"Sampling Frequency:  {samp_freq} Hz\n"
+        f"Sampling started at: {start_time:.4f} s\n"
+        f"Tip: Time 0 is the time of first trigger\n"
+        f"------------------------------------------------\n"
+    )
     LGR.info(summary)
-    utils.write_file(outfile, '.log', summary)
+    utils.write_file(outfile, ".log", summary)
 
 
 def print_json(outfile, samp_freq, time_offset, ch_name):
@@ -110,26 +112,42 @@ def print_json(outfile, samp_freq, time_offset, ch_name):
         File containing information for BIDS.
     """
     start_time = -time_offset
-    summary = dict(SamplingFrequency=samp_freq,
-                   StartTime=round(start_time, 4),
-                   Columns=ch_name)
+    summary = dict(SamplingFrequency=samp_freq, StartTime=round(start_time, 4), Columns=ch_name)
     utils.write_json(outfile, summary, indent=4, sort_keys=False)
 
 
 @due.dcite(
-     Doi('10.5281/zenodo.3470091'),
-     path='phys2bids',
-     description='Conversion of physiological trace data to BIDS format',
-     version=__version__,
-     cite_module=True)
+    Doi("10.5281/zenodo.3470091"),
+    path="phys2bids",
+    description="Conversion of physiological trace data to BIDS format",
+    version=__version__,
+    cite_module=True,
+)
 @due.dcite(
-    Doi('10.1038/sdata.2016.44'),
-    path='phys2bids',
-    description='The BIDS specification',
-    cite_module=True)
-def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
-              sub=None, ses=None, chtrig=0, chsel=None, num_timepoints_expected=None,
-              tr=None, thr=None, pad=9, ch_name=[], yml='', debug=False, quiet=False):
+    Doi("10.1038/sdata.2016.44"),
+    path="phys2bids",
+    description="The BIDS specification",
+    cite_module=True,
+)
+def phys2bids(
+    filename,
+    info=False,
+    indir=".",
+    outdir=".",
+    heur_file=None,
+    sub=None,
+    ses=None,
+    chtrig=0,
+    chsel=None,
+    num_timepoints_expected=None,
+    tr=None,
+    thr=None,
+    pad=9,
+    ch_name=[],
+    yml="",
+    debug=False,
+    quiet=False,
+):
     """
     Run main workflow of phys2bids.
 
@@ -148,20 +166,20 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
     # #!# This can probably be done while parsing?
     outdir = os.path.abspath(outdir)
     os.makedirs(outdir, exist_ok=True)
-    os.makedirs(os.path.join(outdir, 'code'), exist_ok=True)
-    conversion_path = os.path.join(outdir, 'code', 'conversion')
+    os.makedirs(os.path.join(outdir, "code"), exist_ok=True)
+    conversion_path = os.path.join(outdir, "code", "conversion")
     os.makedirs(conversion_path, exist_ok=True)
 
     # Create logfile name
-    basename = 'phys2bids_'
-    extension = 'tsv'
-    isotime = datetime.datetime.now().strftime('%Y-%m-%dT%H%M%S')
-    logname = os.path.join(conversion_path, (basename + isotime + '.' + extension))
+    basename = "phys2bids_"
+    extension = "tsv"
+    isotime = datetime.datetime.now().strftime("%Y-%m-%dT%H%M%S")
+    logname = os.path.join(conversion_path, (basename + isotime + "." + extension))
 
     # Set logging format
     log_formatter = logging.Formatter(
-        '%(asctime)s\t%(name)-12s\t%(levelname)-8s\t%(message)s',
-        datefmt='%Y-%m-%dT%H:%M:%S')
+        "%(asctime)s\t%(name)-12s\t%(levelname)-8s\t%(message)s", datefmt="%Y-%m-%dT%H:%M:%S"
+    )
 
     # Set up logging file and open it for writing
     log_handler = logging.FileHandler(logname)
@@ -169,24 +187,29 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
     sh = logging.StreamHandler()
 
     if quiet:
-        logging.basicConfig(level=logging.WARNING,
-                            handlers=[log_handler, sh], format='%(levelname)-10s %(message)s')
+        logging.basicConfig(
+            level=logging.WARNING,
+            handlers=[log_handler, sh],
+            format="%(levelname)-10s %(message)s",
+        )
     elif debug:
-        logging.basicConfig(level=logging.DEBUG,
-                            handlers=[log_handler, sh], format='%(levelname)-10s %(message)s')
+        logging.basicConfig(
+            level=logging.DEBUG, handlers=[log_handler, sh], format="%(levelname)-10s %(message)s"
+        )
     else:
-        logging.basicConfig(level=logging.INFO,
-                            handlers=[log_handler, sh], format='%(levelname)-10s %(message)s')
+        logging.basicConfig(
+            level=logging.INFO, handlers=[log_handler, sh], format="%(levelname)-10s %(message)s"
+        )
 
-    version_number = _version.get_versions()['version']
-    LGR.info(f'Currently running phys2bids version {version_number}')
-    LGR.info(f'Input file is {filename}')
+    version_number = _version.get_versions()["version"]
+    LGR.info(f"Currently running phys2bids version {version_number}")
+    LGR.info(f"Input file is {filename}")
 
     # Save call.sh
-    arg_str = ' '.join(sys.argv[1:])
-    call_str = f'phys2bids {arg_str}'
-    f = open(os.path.join(conversion_path, 'call.sh'), "a")
-    f.write(f'#!bin/bash \n{call_str}')
+    arg_str = " ".join(sys.argv[1:])
+    call_str = f"phys2bids {arg_str}"
+    f = open(os.path.join(conversion_path, "call.sh"), "a")
+    f.write(f"#!bin/bash \n{call_str}")
     f.close()
 
     # Check options to make them internally coherent pt. II
@@ -200,7 +223,7 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
                                              indir)
 
     if heur_file:
-        heur_file = utils.check_input_ext(heur_file, '.py')
+        heur_file = utils.check_input_ext(heur_file, ".py")
         utils.check_file_exists(heur_file)
 
     infile = os.path.join(indir, filename)
@@ -214,34 +237,40 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
     if tr is not None and num_timepoints_expected is not None:
         # If tr and ntp were specified, check that tr is either length one or ntp.
         if len(num_timepoints_expected) != len(tr) and len(tr) != 1:
-            raise RuntimeError('Number of sequence types listed with TR '
-                               'doesn\'t match expected number of runs in '
-                               'the session')
+            raise RuntimeError(
+                "Number of sequence types listed with TR "
+                "doesn't match expected number of runs in "
+                "the session"
+            )
 
     # Read file!
-    LGR.info(f'Reading the file {infile}')
-    if ftype == 'acq':
+    LGR.info(f"Reading the file {infile}")
+    if ftype == "acq":
         from phys2bids.io import load_acq
+
         phys_in = load_acq(infile, chtrig)
-    elif ftype == 'txt':
+    elif ftype == "txt":
         from phys2bids.io import load_txt
+
         phys_in = load_txt(infile, chtrig)
-    elif ftype == 'mat':
+    elif ftype == "mat":
         from phys2bids.io import load_mat
+
         phys_in = load_mat(infile, chtrig)
     elif ftype == 'gep':
         from phys2bids.io import load_gep
         phys_in = load_gep(infile)
 
-    LGR.info('Checking that units of measure are BIDS compatible')
+    LGR.info("Checking that units of measure are BIDS compatible")
     for index, unit in enumerate(phys_in.units):
         phys_in.units[index] = bids.bidsify_units(unit)
 
-    LGR.info('Reading infos')
+    LGR.info("Reading infos")
     phys_in.print_info(filename)
     # #!# Here the function viz.plot_channel should be called
-    viz.plot_all(phys_in.ch_name, phys_in.timeseries, phys_in.units,
-                 phys_in.freq, infile, conversion_path)
+    viz.plot_all(
+        phys_in.ch_name, phys_in.timeseries, phys_in.units, phys_in.freq, infile, conversion_path
+    )
     # If only info were asked, end here.
     if info:
         return
@@ -264,7 +293,7 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
 
     # If requested, change channel names.
     if ch_name:
-        LGR.info('Renaming channels with given names')
+        LGR.info("Renaming channels with given names")
         phys_in.rename_channels(ch_name)
 
     # Checking acquisition type via user's input
@@ -279,26 +308,28 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
                 tr = np.ones(len(num_timepoints_expected)) * tr[0]
 
             # Sum of values in ntp_list should be equivalent to num_timepoints_found
-            phys_in.check_trigger_amount(thr=thr,
-                                         num_timepoints_expected=sum(num_timepoints_expected),
-                                         tr=1)
+            phys_in.check_trigger_amount(
+                thr=thr, num_timepoints_expected=sum(num_timepoints_expected), tr=1
+            )
 
             # Check that sum of tp expected is equivalent to num_timepoints_found,
             # if it passes call slice4phys
             if phys_in.num_timepoints_found != sum(num_timepoints_expected):
-                raise RuntimeError('The number of triggers found is different '
-                                   'than expected. Better stop now than break '
-                                   'something.')
+                raise RuntimeError(
+                    "The number of triggers found is different "
+                    "than expected. Better stop now than break "
+                    "something."
+                )
 
             # slice the recording based on user's entries
             # !!! ATTENTION: PHYS_IN GETS OVERWRITTEN AS DICTIONARY
-            phys_in = slice4phys(phys_in, num_timepoints_expected, tr,
-                                 phys_in.thr, pad)
+            phys_in = slice4phys(phys_in, num_timepoints_expected, tr, phys_in.thr, pad)
             # returns a dictionary in the form {take_idx: phys_in[startpoint, endpoint]}
 
             # save a figure for each take | give the right acquisition parameters for takes
-            fileprefix = os.path.join(conversion_path,
-                                      os.path.splitext(os.path.basename(filename))[0])
+            fileprefix = os.path.join(
+                conversion_path, os.path.splitext(os.path.basename(filename))[0]
+            )
             for i, take in enumerate(phys_in.keys()):
                 plot_fileprefix = f'{fileprefix}_{take:02d}'
                 viz.export_trigger_plot(phys_in[take], phys_in[take].trigger_idx,
@@ -323,8 +354,10 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
             phys_in = {1: phys_in}
 
     else:
-        LGR.warning('Skipping trigger pulse count. If you want to run it, '
-                    'call phys2bids using both "-ntp" and "-tr" arguments')
+        LGR.warning(
+            "Skipping trigger pulse count. If you want to run it, "
+            'call phys2bids using both "-ntp" and "-tr" arguments'
+        )
         # !!! ATTENTION: PHYS_IN GETS OVERWRITTEN AS DICTIONARY
         phys_in = {1: phys_in}
 
@@ -335,21 +368,27 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
     uniq_freq_list = set(phys_in[1].freq)
     freq_amount = len(uniq_freq_list)
     if freq_amount > 1:
-        LGR.info(f'Found {freq_amount} different frequencies in input!')
+        LGR.info(f"Found {freq_amount} different frequencies in input!")
 
     if take_amount > 1:
-        LGR.info(f'Found {take_amount} different takes in input!')
+        LGR.info(f"Found {take_amount} different takes in input!")
 
-    LGR.info(f'Preparing {freq_amount*take_amount} output files.')
+    LGR.info(f"Preparing {freq_amount*take_amount} output files.")
     # Create phys_out dict that will have a blueprint object for each different frequency
     phys_out = {}
 
     if heur_file is not None and sub is not None:
-        LGR.info(f'Preparing BIDS output using {heur_file}')
+        LGR.info(f"Preparing BIDS output using {heur_file}")
         # If heuristics are used, init a dict of arguments to pass to use_heuristic
-        heur_args = {'heur_file': heur_file, 'sub': sub, 'ses': ses,
-                     'filename': filename, 'outdir': outdir, 'take': '',
-                     'record_label': ''}
+        heur_args = {
+            "heur_file": heur_file,
+            "sub": sub,
+            "ses": ses,
+            "filename": filename,
+            "outdir": outdir,
+            "take": "",
+            "record_label": "",
+        }
         # Generate participants.tsv file if it doesn't exist already.
         # Update the file if the subject is not in the file.
         # Do not update if the subject is already in the file.
@@ -358,18 +397,23 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
         bids.dataset_description_file(outdir)
         # Generate README file if it doesn't exist already.
         bids.readme_file(outdir)
-        cp(heur_file, os.path.join(conversion_path,
-           os.path.splitext(os.path.basename(heur_file))[0] + '.py'))
+        cp(
+            heur_file,
+            os.path.join(
+                conversion_path, os.path.splitext(os.path.basename(heur_file))[0] + ".py"
+            ),
+        )
     elif heur_file is not None and sub is None:
-        LGR.warning('While "-heur" was specified, option "-sub" was not.\n'
-                    'Skipping BIDS formatting.')
+        LGR.warning(
+            'While "-heur" was specified, option "-sub" was not.\n' "Skipping BIDS formatting."
+        )
 
     # Export a (set of) phys_out for each element in phys_in
     # run keys start from 1 (human friendly)
     for take in phys_in.keys():
         for uniq_freq in uniq_freq_list:
             # Initialise the key for the (possibly huge amount of) dictionary entries
-            key = f'{take}_{uniq_freq}'
+            key = f"{take}_{uniq_freq}"
             # copy the phys_in object to the new dict entry
             phys_out[key] = deepcopy(phys_in[take])
             # this counter will take into account how many channels are eliminated
@@ -392,9 +436,14 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
             if uniq_freq != phys_in[take].freq[0]:
                 phys_out[key].ch_name.insert(0, phys_in[take].ch_name[0])
                 phys_out[key].units.insert(0, phys_in[take].units[0])
-                phys_out[key].timeseries.insert(0, np.linspace(phys_in[take].timeseries[0][0],
-                                                phys_in[take].timeseries[0][-1],
-                                                num=phys_out[key].timeseries[0].shape[0]))
+                phys_out[key].timeseries.insert(
+                    0,
+                    np.linspace(
+                        phys_in[take].timeseries[0][0],
+                        phys_in[take].timeseries[0][-1],
+                        num=phys_out[key].timeseries[0].shape[0],
+                    ),
+                )
             # Add trigger channel in the proper frequency.
             if uniq_freq != phys_in[take].freq[phys_in[take].trigger_idx]:
                 phys_out[key].ch_name.insert(1, phys_in[take].ch_name[phys_in[take].trigger_idx])
@@ -411,16 +460,16 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
 
         # Preparing output parameters: name and folder.
         for uniq_freq in uniq_freq_list:
-            key = f'{take}_{uniq_freq}'
+            key = f"{take}_{uniq_freq}"
             # If possible, prepare bids renaming.
             if heur_file is not None and sub is not None:
                 # Add take info to heur_args if more than one take is present
                 if take_amount > 1:
-                    heur_args['take'] = f'{take:02d}'
+                    heur_args["take"] = f"{take:02d}"
 
                 # Append "recording-freq" to filename if more than one freq
                 if freq_amount > 1:
-                    heur_args['record_label'] = f'{uniq_freq:.0f}Hz'
+                    heur_args["record_label"] = f"{uniq_freq:.0f}Hz"
 
                 phys_out[key].filename = bids.use_heuristic(**heur_args)
 
@@ -429,35 +478,50 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
                 if take_amount > 1:
                     for n, k in enumerate(phys_out.keys()):
                         if k != key and phys_out[key].filename == phys_out[k].filename:
-                            phys_out[key].filename = (f'{phys_out[key].filename}'
-                                                      f'_take-{take:02d}')
-                            LGR.warning('Identified multiple outputs with the same name.\n'
-                                        'Appending fake label to avoid overwriting.\n'
-                                        '!!! ATTENTION !!! the output is not BIDS compliant.\n'
-                                        'Please check heuristics to solve the problem.')
+                            phys_out[key].filename = (
+                                f"{phys_out[key].filename}" f"_take-{take:02d}"
+                            )
+                            LGR.warning(
+                                "Identified multiple outputs with the same name.\n"
+                                "Appending fake label to avoid overwriting.\n"
+                                "!!! ATTENTION !!! the output is not BIDS compliant.\n"
+                                "Please check heuristics to solve the problem."
+                            )
 
             else:
-                phys_out[key].filename = os.path.join(outdir,
-                                                      os.path.splitext(os.path.basename(filename)
-                                                                       )[0])
+                phys_out[key].filename = os.path.join(
+                    outdir, os.path.splitext(os.path.basename(filename))[0]
+                )
                 # Append "take" to filename if more than one take
                 if take_amount > 1:
-                    phys_out[key].filename = f'{phys_out[key].filename}_{take:02d}'
+                    phys_out[key].filename = f"{phys_out[key].filename}_{take:02d}"
                 # Append "freq" to filename if more than one freq
                 if freq_amount > 1:
-                    phys_out[key].filename = f'{phys_out[key].filename}_{uniq_freq:.0f}Hz'
+                    phys_out[key].filename = f"{phys_out[key].filename}_{uniq_freq:.0f}Hz"
 
-            LGR.info(f'Exporting files for take {take} freq {uniq_freq}')
-            np.savetxt(phys_out[key].filename + '.tsv.gz',
-                       phys_out[key].timeseries, fmt='%.8e', delimiter='\t')
-            print_json(phys_out[key].filename, phys_out[key].freq,
-                       phys_out[key].start_time, phys_out[key].ch_name)
-            print_summary(filename, num_timepoints_expected,
-                          phys_in[take].num_timepoints_found, uniq_freq,
-                          phys_out[key].start_time,
-                          os.path.join(conversion_path,
-                                       os.path.splitext(os.path.basename(phys_out[key].filename)
-                                                        )[0]))
+            LGR.info(f"Exporting files for take {take} freq {uniq_freq}")
+            np.savetxt(
+                phys_out[key].filename + ".tsv.gz",
+                phys_out[key].timeseries,
+                fmt="%.8e",
+                delimiter="\t",
+            )
+            print_json(
+                phys_out[key].filename,
+                phys_out[key].freq,
+                phys_out[key].start_time,
+                phys_out[key].ch_name,
+            )
+            print_summary(
+                filename,
+                num_timepoints_expected,
+                phys_in[take].num_timepoints_found,
+                uniq_freq,
+                phys_out[key].start_time,
+                os.path.join(
+                    conversion_path, os.path.splitext(os.path.basename(phys_out[key].filename))[0]
+                ),
+            )
 
 
 def _main(argv=None):
@@ -465,7 +529,7 @@ def _main(argv=None):
     phys2bids(**vars(options))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     _main(sys.argv[1:])
 
 """

--- a/phys2bids/phys2bids.py
+++ b/phys2bids/phys2bids.py
@@ -300,7 +300,6 @@ def phys2bids(
 
     # Checking acquisition type via user's input
     if tr is not None and num_timepoints_expected is not None:
-
         #  Multi-run acquisition type section
         #  Check list length, more than 1 means multi-run
         if len(num_timepoints_expected) > 1:

--- a/phys2bids/phys2bids.py
+++ b/phys2bids/phys2bids.py
@@ -216,11 +216,10 @@ def phys2bids(
     # #!# This can probably be done while parsing?
     indir = os.path.abspath(indir)
     if chtrig and chtrig < 0:
-        raise RuntimeError('Wrong trigger channel. Channel indexing starts with 0!')
+        raise RuntimeError("Wrong trigger channel. Channel indexing starts with 0!")
 
     utils.check_ge(filename, indir)
-    filename, ftype = utils.check_input_type(filename,
-                                             indir)
+    filename, ftype = utils.check_input_type(filename, indir)
 
     if heur_file:
         heur_file = utils.check_input_ext(heur_file, ".py")
@@ -257,8 +256,9 @@ def phys2bids(
         from phys2bids.io import load_mat
 
         phys_in = load_mat(infile, chtrig)
-    elif ftype == 'gep':
+    elif ftype == "gep":
         from phys2bids.io import load_gep
+
         phys_in = load_gep(infile)
 
     LGR.info("Checking that units of measure are BIDS compatible")
@@ -277,15 +277,17 @@ def phys2bids(
 
     # The next few lines remove the undesired channels from phys_in.
     if chsel:
-        LGR.info('Dropping unselected channels')
+        LGR.info("Dropping unselected channels")
         chsel.insert(0, 0)
         if phys_in.trigger_idx not in chsel:
-            LGR.warning(f'The selected channels {tuple(chsel)} do not '
-                        f'contain the trigger channel ({phys_in.trigger_idx}). '
-                        f'Adding channel {phys_in.trigger_idx} to the selection.')
+            LGR.warning(
+                f"The selected channels {tuple(chsel)} do not "
+                f"contain the trigger channel ({phys_in.trigger_idx}). "
+                f"Adding channel {phys_in.trigger_idx} to the selection."
+            )
             chsel.extend(phys_in.trigger_idx)
         chsel.sort()
-        for i in range(phys_in.ch_amount-1, 0, -1):
+        for i in range(phys_in.ch_amount - 1, 0, -1):
             if i not in chsel:
                 phys_in.delete_at_index(i)
         # Update trigger index
@@ -331,11 +333,17 @@ def phys2bids(
                 conversion_path, os.path.splitext(os.path.basename(filename))[0]
             )
             for i, take in enumerate(phys_in.keys()):
-                plot_fileprefix = f'{fileprefix}_{take:02d}'
-                viz.export_trigger_plot(phys_in[take], phys_in[take].trigger_idx,
-                                        plot_fileprefix, tr[i],
-                                        num_timepoints_expected[i], filename,
-                                        sub, ses)
+                plot_fileprefix = f"{fileprefix}_{take:02d}"
+                viz.export_trigger_plot(
+                    phys_in[take],
+                    phys_in[take].trigger_idx,
+                    plot_fileprefix,
+                    tr[i],
+                    num_timepoints_expected[i],
+                    filename,
+                    sub,
+                    ses,
+                )
 
         # Single take acquisition type, or : nothing to split workflow
         else:
@@ -343,11 +351,19 @@ def phys2bids(
             # and the time offset.
             phys_in.check_trigger_amount(thr, num_timepoints_expected[0], tr[0])
             # save a figure of the trigger
-            fileprefix = os.path.join(conversion_path,
-                                      os.path.splitext(os.path.basename(filename))[0])
-            viz.export_trigger_plot(phys_in, phys_in.trigger_idx, fileprefix, tr[0],
-                                    num_timepoints_expected[0], filename,
-                                    sub, ses)
+            fileprefix = os.path.join(
+                conversion_path, os.path.splitext(os.path.basename(filename))[0]
+            )
+            viz.export_trigger_plot(
+                phys_in,
+                phys_in.trigger_idx,
+                fileprefix,
+                tr[0],
+                num_timepoints_expected[0],
+                filename,
+                sub,
+                ses,
+            )
 
             # Reassign phys_in as dictionary
             # !!! ATTENTION: PHYS_IN GETS OVERWRITTEN AS DICTIONARY
@@ -453,8 +469,8 @@ def phys2bids(
                     np.interp(
                         phys_out[key].timeseries[0],
                         phys_in[take].timeseries[0],
-                        phys_in[take].timeseries[phys_in[take].trigger_idx]
-                    )
+                        phys_in[take].timeseries[phys_in[take].trigger_idx],
+                    ),
                 )
             phys_out[key] = BlueprintOutput.init_from_blueprint(phys_out[key])
 

--- a/phys2bids/physio_obj.py
+++ b/phys2bids/physio_obj.py
@@ -340,7 +340,7 @@ class BlueprintInput:
         # Operate on each channel on its own
         for n, channel in enumerate(self.timeseries):
             idx_dict = {"start": idx.start, "stop": idx.stop, "step": idx.step}
-            # Adapt the slicing indexes to the right requency
+            # Adapt the slicing indexes to the right frequency
             for i in ["start", "stop", "step"]:
                 if idx_dict[i]:
                     idx_dict[i] = int(
@@ -623,9 +623,9 @@ class BlueprintInput:
             trigger_idx : int
                 Automatically retrieved trigger index
         """
-        LGR.info('Running automatic trigger detection.')
-        LGR.info('Matching channel names with known trigger names first.')
-        joint_match = '§'.join(TRIGGER_NAMES)
+        LGR.info("Running automatic trigger detection.")
+        LGR.info("Matching channel names with known trigger names first.")
+        joint_match = "§".join(TRIGGER_NAMES)
         indexes = []
         for n, case in enumerate(self.ch_name):
             name = re.split(r"(\W+|\d|_|\s)", case)
@@ -644,7 +644,7 @@ class BlueprintInput:
                 self.trigger_idx = int(indexes[0])
         else:
             # Time-domain automatic trigger detection
-            LGR.info('Find the trigger channel by measuring data distance from its value limits.')
+            LGR.info("Find the trigger channel by measuring data distance from its value limits.")
             # Create numpy array with all channels (excluding time)
             channel_ts = np.array(self.timeseries[1:])
 

--- a/phys2bids/physio_obj.py
+++ b/phys2bids/physio_obj.py
@@ -43,7 +43,7 @@ def is_valid(var, var_type, list_type=None):
         If var is not of var_type
     """
     if not isinstance(var, var_type):
-        raise AttributeError(f'The given variable is not a {var_type}')
+        raise AttributeError(f"The given variable is not a {var_type}")
 
     if var_type is list and list_type is not None:
         for element in var:
@@ -107,7 +107,7 @@ def are_equal(self, other):
     def _deal_with_dict_value_error(self, other):
         # Check if "self" has a 'timeseries' key. If not, return False.
         try:
-            self['timeseries']
+            self["timeseries"]
         except KeyError:
             return False
         except TypeError:
@@ -116,16 +116,17 @@ def are_equal(self, other):
             # Check that the two objects have the same keys.
             # If not, return False, otherwise loop through the timeseries key.
             if self.keys() == other.keys():
-                alltrue_timeseries = [False] * len(self['timeseries'])
+                alltrue_timeseries = [False] * len(self["timeseries"])
                 alltrue_keys = [False] * len(self)
                 for j, key in enumerate(self.keys()):
-                    if key == 'timeseries':
-                        for i in range(len(self['timeseries'])):
-                            alltrue_timeseries[i] = (self['timeseries'][i].all()
-                                                     == other['timeseries'][i].all())
+                    if key == "timeseries":
+                        for i in range(len(self["timeseries"])):
+                            alltrue_timeseries[i] = (
+                                self["timeseries"][i].all() == other["timeseries"][i].all()
+                            )
                         alltrue_keys[j] = all(alltrue_timeseries)
                     else:
-                        alltrue_keys[j] = (self[key] == other[key])
+                        alltrue_keys[j] = self[key] == other[key]
                 return all(alltrue_keys)
             else:
                 return False
@@ -158,7 +159,7 @@ def are_equal(self, other):
                     return _deal_with_dict_value_error(self, other)
 
 
-class BlueprintInput():
+class BlueprintInput:
     """
     Main input object for phys2bids.
 
@@ -230,23 +231,33 @@ class BlueprintInput():
     - Actual number of channels +1 <= ch_amount
     """
 
-    def __init__(self, timeseries, freq, ch_name, units, trigger_idx,
-                 num_timepoints_found=None, thr=None, time_offset=0):
+    def __init__(
+        self,
+        timeseries,
+        freq,
+        ch_name,
+        units,
+        trigger_idx,
+        num_timepoints_found=None,
+        thr=None,
+        time_offset=0,
+    ):
         """Initialise BlueprintInput (see class docstring)."""
         self.timeseries = deepcopy(is_valid(timeseries, list, list_type=np.ndarray))
-        self.freq = deepcopy(has_size(is_valid(freq, list,
-                                      list_type=(int, float)),
-                             self.ch_amount, 0.0))
-        self.ch_name = deepcopy(has_size(ch_name, self.ch_amount, 'unknown'))
-        self.units = deepcopy(has_size(units, self.ch_amount, '[]'))
-
+        self.freq = deepcopy(
+            has_size(is_valid(freq, list, list_type=(int, float)), self.ch_amount, 0.0)
+        )
+        self.ch_name = deepcopy(has_size(ch_name, self.ch_amount, "unknown"))
+        self.units = deepcopy(has_size(units, self.ch_amount, "[]"))
         self.trigger_idx = deepcopy(is_valid(trigger_idx, int))
         if trigger_idx == 0:
             self.auto_trigger_selection()
         else:
             if ch_name[trigger_idx] not in TRIGGER_NAMES:
-                LGR.info('Trigger channel name is not in our trigger channel name alias list. '
-                         'Please make sure you choose the proper channel.')
+                LGR.info(
+                    "Trigger channel name is not in our trigger channel name alias list. "
+                    "Please make sure you choose the proper channel."
+                )
 
         self.num_timepoints_found = deepcopy(num_timepoints_found)
         self.thr = deepcopy(thr)
@@ -320,33 +331,41 @@ class BlueprintInput():
 
         # Check that the indexes are not out of bounds
         if idx.start >= trigger_length or idx.stop > trigger_length:
-            raise IndexError(f'Slice ({idx.start}, {idx.stop}) is out of '
-                             f'bounds for channel {self.trigger_idx} '
-                             f'with size {trigger_length}')
+            raise IndexError(
+                f"Slice ({idx.start}, {idx.stop}) is out of "
+                f"bounds for channel {self.trigger_idx} "
+                f"with size {trigger_length}"
+            )
 
         # Operate on each channel on its own
         for n, channel in enumerate(self.timeseries):
-            idx_dict = {'start': idx.start, 'stop': idx.stop, 'step': idx.step}
-            # Adapt the slicing indexes to the right frequency
-            for i in ['start', 'stop', 'step']:
+            idx_dict = {"start": idx.start, "stop": idx.stop, "step": idx.step}
+            # Adapt the slicing indexes to the right requency
+            for i in ["start", "stop", "step"]:
                 if idx_dict[i]:
-                    idx_dict[i] = int(np.floor(self.freq[n]
-                                               / self.freq[self.trigger_idx]
-                                               * idx_dict[i]))
+                    idx_dict[i] = int(
+                        np.floor(self.freq[n] / self.freq[self.trigger_idx] * idx_dict[i])
+                    )
 
             # Correct the slicing stop if necessary
-            if idx_dict['start'] == idx_dict['stop'] or return_instant:
-                idx_dict['stop'] = idx_dict['start'] + 1
+            if idx_dict["start"] == idx_dict["stop"] or return_instant:
+                idx_dict["stop"] = idx_dict["start"] + 1
             elif trigger_length == idx.stop:
-                idx_dict['stop'] = len(channel)
+                idx_dict["stop"] = len(channel)
 
-            new_idx = slice(idx_dict['start'], idx_dict['stop'], idx_dict['step'])
+            new_idx = slice(idx_dict["start"], idx_dict["stop"], idx_dict["step"])
             sliced_timeseries[n] = channel[new_idx]
 
-        sliced_bp = BlueprintInput(sliced_timeseries, self.freq, self.ch_name,
-                                   self.units, self.trigger_idx,
-                                   self.num_timepoints_found, self.thr,
-                                   self.time_offset)
+        sliced_bp = BlueprintInput(
+            sliced_timeseries,
+            self.freq,
+            self.ch_name,
+            self.units,
+            self.trigger_idx,
+            self.num_timepoints_found,
+            self.thr,
+            self.time_offset,
+        )
 
         sliced_bp._time_resampled_to_trigger = self._time_resampled_to_trigger
         return sliced_bp
@@ -383,13 +402,16 @@ class BlueprintInput():
         self.ch_name: list of str
             Changes content to new_name.
         """
-        if 'time' in new_names:
-            del new_names[new_names.index('time')]
+        if "time" in new_names:
+            del new_names[new_names.index("time")]
 
-        new_names = ['time', ] + new_names
+        new_names = [
+            "time",
+        ] + new_names
 
-        self.ch_name = has_size(is_valid(new_names, list, list_type=str),
-                                self.ch_amount, 'unknown')
+        self.ch_name = has_size(
+            is_valid(new_names, list, list_type=str), self.ch_amount, "unknown"
+        )
 
     def return_index(self, idx):
         """
@@ -406,8 +428,13 @@ class BlueprintInput():
             Tuple containing the proper list entry of all the
             properties of the object with index `idx`
         """
-        return (self.timeseries[idx], self.ch_amount, self.freq[idx],
-                self.ch_name[idx], self.units[idx])
+        return (
+            self.timeseries[idx],
+            self.ch_amount,
+            self.freq[idx],
+            self.ch_name[idx],
+            self.units[idx],
+        )
 
     def delete_at_index(self, idx):
         """
@@ -438,8 +465,7 @@ class BlueprintInput():
         del self.units[idx]
 
         if self.trigger_idx == idx:
-            LGR.warning('Removing trigger channel - are you sure you are doing'
-                        'the right thing?')
+            LGR.warning("Removing trigger channel - are you sure you are doing" "the right thing?")
             self.trigger_idx = 0
 
     def check_trigger_amount(self, thr=None, num_timepoints_expected=0, tr=0):
@@ -470,18 +496,20 @@ class BlueprintInput():
             The property `timeseries` is shifted with the 0 being
             the time of first trigger.
         """
-        LGR.info('Counting trigger points')
+        LGR.info("Counting trigger points")
         # Use the trigger channel to find the TRs,
         # comparing it to a given threshold.
         trigger = self.timeseries[self.trigger_idx]
         time = self.timeseries[0]
-        LGR.info(f'The trigger is in channel {self.trigger_idx}')
+        LGR.info(f"The trigger is in channel {self.trigger_idx}")
         # Check that trigger and time channels have the same length.
         # If not, resample time to the length of the trigger
         if len(time) != len(trigger):
-            LGR.warning('The trigger channel has a different sampling '
-                        'from the registered time. Using a resampled version '
-                        'of time to find the starting time.')
+            LGR.warning(
+                "The trigger channel has a different sampling "
+                "from the registered time. Using a resampled version "
+                "of time to find the starting time."
+            )
             time = np.linspace(time[0], time[-1], len(trigger))
 
             self._time_resampled_to_trigger = time
@@ -496,46 +524,52 @@ class BlueprintInput():
             thr = np.mean(trigger)
             flag = 1
         timepoints = trigger > thr
-        num_timepoints_found = len([is_true for is_true, _ in groupby(timepoints,
-                                    lambda x: x != 0) if is_true])
+        num_timepoints_found = len(
+            [is_true for is_true, _ in groupby(timepoints, lambda x: x != 0) if is_true]
+        )
         if flag == 1:
-            LGR.info(f'The number of timepoints according to the std_thr method '
-                     f'is {num_timepoints_found}. The computed threshold is {thr:.4f}')
+            LGR.info(
+                f"The number of timepoints according to the std_thr method "
+                f"is {num_timepoints_found}. The computed threshold is {thr:.4f}"
+            )
         else:
-            LGR.info(f'The number of timepoints found with the manual threshold of {thr:.4f} '
-                     f'is {num_timepoints_found}')
+            LGR.info(
+                f"The number of timepoints found with the manual threshold of {thr:.4f} "
+                f"is {num_timepoints_found}"
+            )
         time_offset = time[timepoints.argmax()]
 
         if num_timepoints_expected:
-            LGR.info('Checking number of timepoints')
+            LGR.info("Checking number of timepoints")
             if num_timepoints_found > num_timepoints_expected:
-                timepoints_extra = (num_timepoints_found
-                                    - num_timepoints_expected)
-                LGR.warning(f'Found {timepoints_extra} timepoints'
-                            ' more than expected!\n'
-                            'Assuming extra timepoints are at the end '
-                            '(try again with a more liberal thr)')
+                timepoints_extra = num_timepoints_found - num_timepoints_expected
+                LGR.warning(
+                    f"Found {timepoints_extra} timepoints"
+                    " more than expected!\n"
+                    "Assuming extra timepoints are at the end "
+                    "(try again with a more liberal thr)"
+                )
 
             elif num_timepoints_found < num_timepoints_expected:
-                timepoints_missing = (num_timepoints_expected
-                                      - num_timepoints_found)
-                LGR.warning(f'Found {timepoints_missing} timepoints'
-                            ' less than expected!')
+                timepoints_missing = num_timepoints_expected - num_timepoints_found
+                LGR.warning(f"Found {timepoints_missing} timepoints" " less than expected!")
                 if tr:
-                    LGR.warning('Correcting time offset, assuming missing '
-                                'timepoints are at the beginning (try again '
-                                'with a more conservative thr)')
-                    time_offset -= (timepoints_missing * tr)
+                    LGR.warning(
+                        "Correcting time offset, assuming missing "
+                        "timepoints are at the beginning (try again "
+                        "with a more conservative thr)"
+                    )
+                    time_offset -= timepoints_missing * tr
                 else:
-                    LGR.warning('Can\'t correct time offset - you should '
-                                'specify the TR')
+                    LGR.warning("Can't correct time offset - you should " "specify the TR")
 
             else:
-                LGR.info('Found just the right amount of timepoints!')
+                LGR.info("Found just the right amount of timepoints!")
 
         else:
-            LGR.warning('The necessary options to find the amount of timepoints '
-                        'were not provided.')
+            LGR.warning(
+                "The necessary options to find the amount of timepoints " "were not provided."
+            )
         self.thr = thr
         self.time_offset = time_offset
         self.timeseries[0] = self.timeseries[0] - time_offset
@@ -557,12 +591,12 @@ class BlueprintInput():
             Returns to stdout (e.g. on screen) channels,
             their names and their sampling rate.
         """
-        info = (f'\n------------------------------------------------'
-                f'\nFile {filename} contains:\n')
+        info = (
+            f"\n------------------------------------------------" f"\nFile {filename} contains:\n"
+        )
         for ch in range(1, self.ch_amount):
-            info = info + (f'{ch:02d}. {self.ch_name[ch]};'
-                           f' sampled at {self.freq[ch]} Hz\n')
-        info = info + '------------------------------------------------\n'
+            info = info + (f"{ch:02d}. {self.ch_name[ch]};" f" sampled at {self.freq[ch]} Hz\n")
+        info = info + "------------------------------------------------\n"
 
         LGR.info(info)
 
@@ -594,16 +628,18 @@ class BlueprintInput():
         joint_match = '§'.join(TRIGGER_NAMES)
         indexes = []
         for n, case in enumerate(self.ch_name):
-            name = re.split(r'(\W+|\d|_|\s)', case)
+            name = re.split(r"(\W+|\d|_|\s)", case)
             name = list(filter(None, name))
 
-            if re.search('|'.join(name), joint_match, re.IGNORECASE):
+            if re.search("|".join(name), joint_match, re.IGNORECASE):
                 indexes = indexes + [n]
 
         if indexes:
             if len(indexes) > 1:
-                raise Exception('More than one possible trigger channel was automatically found. '
-                                'Please run phys2bids specifying the -chtrig argument.')
+                raise Exception(
+                    "More than one possible trigger channel was automatically found. "
+                    "Please run phys2bids specifying the -chtrig argument."
+                )
             else:
                 self.trigger_idx = int(indexes[0])
         else:
@@ -624,10 +660,10 @@ class BlueprintInput():
             # Set the trigger as the channel with the smallest distance
             self.trigger_idx = int(np.nanargmin(distance_mean) + 1)
 
-        LGR.info(f'{self.ch_name[self.trigger_idx]} selected as trigger channel')
+        LGR.info(f"{self.ch_name[self.trigger_idx]} selected as trigger channel")
 
 
-class BlueprintOutput():
+class BlueprintOutput:
     """
     Main output object for phys2bids.
 
@@ -668,12 +704,12 @@ class BlueprintOutput():
         method to populate from input blueprint instead of init
     """
 
-    def __init__(self, timeseries, freq, ch_name, units, start_time, filename=''):
+    def __init__(self, timeseries, freq, ch_name, units, start_time, filename=""):
         """Initialise BlueprintOutput (see class docstring)."""
         self.timeseries = deepcopy(is_valid(timeseries, np.ndarray))
         self.freq = deepcopy(is_valid(freq, (int, float)))
-        self.ch_name = deepcopy(has_size(ch_name, self.ch_amount, 'unknown'))
-        self.units = deepcopy(has_size(units, self.ch_amount, '[]'))
+        self.ch_name = deepcopy(has_size(ch_name, self.ch_amount, "unknown"))
+        self.units = deepcopy(has_size(units, self.ch_amount, "[]"))
         self.start_time = deepcopy(start_time)
         self.filename = deepcopy(is_valid(filename, str))
 
@@ -719,8 +755,14 @@ class BlueprintOutput():
             Tuple containing the proper list entry of all the
             properties of the object with index `idx`
         """
-        return (self.timeseries[:, idx], self.ch_amount, self.freq,
-                self.ch_name[idx], self.units[idx], self.start_time)
+        return (
+            self.timeseries[:, idx],
+            self.ch_amount,
+            self.freq,
+            self.ch_name[idx],
+            self.units[idx],
+            self.start_time,
+        )
 
     def delete_at_index(self, idx):
         """

--- a/phys2bids/slice4phys.py
+++ b/phys2bids/slice4phys.py
@@ -52,8 +52,9 @@ def find_takes(phys_in, ntp_list, tr_list, thr=None, padding=9):
     for take_idx, take_tps in enumerate(ntp_list):
 
         # correct time offset for this iteration's object
-        phys_in.check_trigger_amount(thr=thr, num_timepoints_expected=take_tps,
-                                     tr=tr_list[take_idx])
+        phys_in.check_trigger_amount(
+            thr=thr, num_timepoints_expected=take_tps, tr=tr_list[take_idx]
+        )
         # If it's the very first take, start the take at sample 0,
         # otherwise start is first trigger (adjust with padding later)
         if take_idx == 0:
@@ -73,9 +74,11 @@ def find_takes(phys_in, ntp_list, tr_list, thr=None, padding=9):
             take_end = int(np.where(phys_in.timeseries[0] > end_sec)[0][0] + padding_fr)
         else:
             take_end = int(phys_in.timeseries[0].shape[0] - 1)
-            LGR.warning(f'The computed end point in second was {end_sec}, '
-                        'but current timeseries only lasts up to '
-                        f'{phys_in.timeseries[0][-1]}')
+            LGR.warning(
+                f"The computed end point in second was {end_sec}, "
+                "but current timeseries only lasts up to "
+                f"{phys_in.timeseries[0][-1]}"
+            )
 
         update = int(take_end - padding_fr + 1)
 
@@ -98,14 +101,19 @@ def find_takes(phys_in, ntp_list, tr_list, thr=None, padding=9):
         # Save *start* and *end_index* in dictionary along with *time_offset* and *ntp found*
         # dict key must be readable by human
         # LGRinfo
-        LGR.info('\n--------------------------------------------------------------\n'
-                 f'Slicing between {(take_start/phys_in.freq[phys_in.trigger_idx])} seconds and '
-                 f'{take_end/phys_in.freq[phys_in.trigger_idx]} seconds\n'
-                 '--------------------------------------------------------------')
+        LGR.info(
+            "\n--------------------------------------------------------------\n"
+            f"Slicing between {(take_start/phys_in.freq[phys_in.trigger_idx])} seconds and "
+            f"{take_end/phys_in.freq[phys_in.trigger_idx]} seconds\n"
+            "--------------------------------------------------------------"
+        )
 
-        take_timestamps[take_idx + 1] = (take_start, take_end,
-                                         phys_in.time_offset,
-                                         phys_in.num_timepoints_found)
+        take_timestamps[take_idx + 1] = (
+            take_start,
+            take_end,
+            phys_in.time_offset,
+            phys_in.num_timepoints_found,
+        )
 
         # update the object so that next iteration will look for the first trigger
         # after previous take's last trigger. maybe padding extends to next take
@@ -141,10 +149,12 @@ def slice4phys(phys_in, ntp_list, tr_list, thr, padding=9):
     """
     phys_in_slices = {}
     # inform the user
-    LGR.warning('\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
-                '\nphys2bids will split the input file according to the given -tr and -ntp'
-                ' arguments'
-                '\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+    LGR.warning(
+        "\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        "\nphys2bids will split the input file according to the given -tr and -ntp"
+        " arguments"
+        "\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    )
     # Find the timestamps
     take_timestamps = find_takes(phys_in, ntp_list, tr_list, thr, padding)
     for n, take in enumerate(take_timestamps.keys()):
@@ -152,11 +162,11 @@ def slice4phys(phys_in, ntp_list, tr_list, thr, padding=9):
         # tmp variable to collect take's info
         take_attributes = take_timestamps[take]
 
-        phys_in_slices[take] = deepcopy(phys_in[take_attributes[0]:take_attributes[1]])
+        phys_in_slices[take] = deepcopy(phys_in[take_attributes[0] : take_attributes[1]])
 
         # take check_trigger amount
-        phys_in_slices[take].check_trigger_amount(thr=thr,
-                                                  num_timepoints_expected=ntp_list[n],
-                                                  tr=tr_list[n])
+        phys_in_slices[take].check_trigger_amount(
+            thr=thr, num_timepoints_expected=ntp_list[n], tr=tr_list[n]
+        )
 
     return phys_in_slices

--- a/phys2bids/slice4phys.py
+++ b/phys2bids/slice4phys.py
@@ -50,7 +50,6 @@ def find_takes(phys_in, ntp_list, tr_list, thr=None, padding=9):
 
     # enumerate user input  num_timepoints_expected
     for take_idx, take_tps in enumerate(ntp_list):
-
         # correct time offset for this iteration's object
         phys_in.check_trigger_amount(
             thr=thr, num_timepoints_expected=take_tps, tr=tr_list[take_idx]
@@ -158,7 +157,6 @@ def slice4phys(phys_in, ntp_list, tr_list, thr, padding=9):
     # Find the timestamps
     take_timestamps = find_takes(phys_in, ntp_list, tr_list, thr, padding)
     for n, take in enumerate(take_timestamps.keys()):
-
         # tmp variable to collect take's info
         take_attributes = take_timestamps[take]
 

--- a/phys2bids/tests/conftest.py
+++ b/phys2bids/tests/conftest.py
@@ -6,13 +6,14 @@ import pytest
 
 
 def pytest_addoption(parser):
-    parser.addoption('--skipintegration', action='store_true',
-                     default=False, help='Skip integration tests.')
+    parser.addoption(
+        "--skipintegration", action="store_true", default=False, help="Skip integration tests."
+    )
 
 
 @pytest.fixture
 def skip_integration(request):
-    return request.config.getoption('--skipintegration')
+    return request.config.getoption("--skipintegration")
 
 
 def fetch_file(osf_id, path, filename):
@@ -38,111 +39,102 @@ def fetch_file(osf_id, path, filename):
     """
     # This restores the same behavior as before.
     # this three lines make tests downloads work in windows
-    if os.name == 'nt':
+    if os.name == "nt":
         orig_sslsocket_init = ssl.SSLSocket.__init__
-        ssl.SSLSocket.__init__ = lambda *args, cert_reqs=ssl.CERT_NONE, **kwargs: orig_sslsocket_init(*args, cert_reqs=ssl.CERT_NONE, **kwargs)
+        ssl.SSLSocket.__init__ = (
+            lambda *args, cert_reqs=ssl.CERT_NONE, **kwargs: orig_sslsocket_init(
+                *args, cert_reqs=ssl.CERT_NONE, **kwargs
+            )
+        )
         ssl._create_default_https_context = ssl._create_unverified_context
-    url = 'https://osf.io/{}/download'.format(osf_id)
+    url = "https://osf.io/{}/download".format(osf_id)
     full_path = os.path.join(path, filename)
     if not os.path.isfile(full_path):
         urlretrieve(url, full_path)
     return full_path
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def testpath(tmp_path_factory):
-    """ Test path that will be used to download all files """
+    """Test path that will be used to download all files"""
     return tmp_path_factory.getbasetemp()
 
 
 @pytest.fixture
 def samefreq_full_acq_file(testpath):
-    return fetch_file('27gqb', testpath,
-                      'Test_belt_pulse_samefreq.acq')
+    return fetch_file("27gqb", testpath, "Test_belt_pulse_samefreq.acq")
 
 
 @pytest.fixture
 def samefreq_short_txt_file(testpath):
-    return fetch_file('4yudk', testpath,
-                      'Test_belt_pulse_samefreq_short.txt')
+    return fetch_file("4yudk", testpath, "Test_belt_pulse_samefreq_short.txt")
 
 
 @pytest.fixture
 def samefreq_noheader_txt_file(testpath):
-    return fetch_file('xbwq9', testpath,
-                      'Test_belt_pulse_samefreq_no_header.txt')
+    return fetch_file("xbwq9", testpath, "Test_belt_pulse_samefreq_no_header.txt")
 
 
 @pytest.fixture
 def multifreq_acq_file(testpath):
-    return fetch_file('9a7yv', testpath,
-                      'Test_belt_pulse_multifreq.acq')
+    return fetch_file("9a7yv", testpath, "Test_belt_pulse_multifreq.acq")
 
 
 @pytest.fixture
 def multifreq_lab_file(testpath):
-    return fetch_file('7se4t', testpath,
-                      'Test1_multifreq_onescan.txt')
+    return fetch_file("7se4t", testpath, "Test1_multifreq_onescan.txt")
 
 
 @pytest.fixture
 def notime_lab_file(testpath):
-    return fetch_file('cv5zr', testpath,
-                      'Test2_samefreq_onescan_notime.txt')
+    return fetch_file("cv5zr", testpath, "Test2_samefreq_onescan_notime.txt")
 
 
 @pytest.fixture
 def multi_run_file(testpath):
-    return fetch_file('gvy84', testpath,
-                      'Test2_samefreq_TWOscans.txt')
+    return fetch_file("gvy84", testpath, "Test2_samefreq_TWOscans.txt")
+
 
 @pytest.fixture
 def matlab_file_labchart(testpath):
-    return fetch_file('2j43t', testpath,
-                      'test_2minRest.mat')
+    return fetch_file("2j43t", testpath, "test_2minRest.mat")
 
 
 @pytest.fixture
 def matlab_file_acq(testpath):
-    return fetch_file('mc96w', testpath,
-                      'Test_belt_pulse_multifreq.mat')
+    return fetch_file("mc96w", testpath, "Test_belt_pulse_multifreq.mat")
+
 
 @pytest.fixture
 def ge_one_gep_file(testpath):
-    return fetch_file('wb84d', testpath,
-                      'PPGData_epiRT_0000000000_00_00_000.gep')
+    return fetch_file("wb84d", testpath, "PPGData_epiRT_0000000000_00_00_000.gep")
+
 
 @pytest.fixture
 def ge_two_gep_files_ppg(testpath):
-    tmp = fetch_file('qawjv', testpath,
-                     'RESPData_epiRT_0000000000_00_00_000.gep')
-    return fetch_file('wb84d', testpath,
-                      'PPGData_epiRT_0000000000_00_00_000.gep')
+    tmp = fetch_file("qawjv", testpath, "RESPData_epiRT_0000000000_00_00_000.gep")
+    return fetch_file("wb84d", testpath, "PPGData_epiRT_0000000000_00_00_000.gep")
+
 
 @pytest.fixture
 def ge_two_gep_files_resp(testpath):
-    tmp = fetch_file('wb84d', testpath,
-                      'PPGData_epiRT_0000000000_00_00_000.gep')
-    return fetch_file('qawjv', testpath,
-                     'RESPData_epiRT_0000000000_00_00_000.gep')
+    tmp = fetch_file("wb84d", testpath, "PPGData_epiRT_0000000000_00_00_000.gep")
+    return fetch_file("qawjv", testpath, "RESPData_epiRT_0000000000_00_00_000.gep")
+
 
 @pytest.fixture
 def ge_one_raw_file(testpath):
-    return fetch_file('u9wsr', testpath,
-                      'PPGData_epiRT_0000000000_00_00_000')
+    return fetch_file("u9wsr", testpath, "PPGData_epiRT_0000000000_00_00_000")
+
 
 @pytest.fixture
 def ge_two_raw_files(testpath):
-    tmp = fetch_file('49xpw', testpath,
-                     'RESPData_epiRT_0000000000_00_00_000')
-    return fetch_file('u9wsr', testpath,
-                      'PPGData_epiRT_0000000000_00_00_000')
+    tmp = fetch_file("49xpw", testpath, "RESPData_epiRT_0000000000_00_00_000")
+    return fetch_file("u9wsr", testpath, "PPGData_epiRT_0000000000_00_00_000")
+
 
 @pytest.fixture
 def ge_badfiles(testpath):
-    tmp = fetch_file('tdmyn', testpath,
-                     'PPGData_epiRT_columnscsv_00_00_000')
-    tmp = fetch_file('b6skq', testpath,
-                     'PPGData_epiRT_columnstsv_00_00_000')
-    return fetch_file('8235b', testpath,
-                      'PPGData_epiRT_string0000_00_00_000')
+    tmp = fetch_file("tdmyn", testpath, "PPGData_epiRT_columnscsv_00_00_000")
+    tmp = fetch_file("b6skq", testpath, "PPGData_epiRT_columnstsv_00_00_000")
+    return fetch_file("8235b", testpath, "PPGData_epiRT_string0000_00_00_000")

--- a/phys2bids/tests/test_bids.py
+++ b/phys2bids/tests/test_bids.py
@@ -89,7 +89,6 @@ def test_dataset_description_file(outdir):
 
 @pytest.mark.parametrize("outdir", ".")
 def test_participants_file(outdir):
-
     # Checks first condition in line 198
     test_sub = "001"
     test_sub_no_yml = "002"

--- a/phys2bids/tests/test_bids.py
+++ b/phys2bids/tests/test_bids.py
@@ -1,9 +1,9 @@
 import os
-from pkg_resources import resource_filename
+from csv import reader
 
 import pytest
 import yaml
-from csv import reader
+from pkg_resources import resource_filename
 
 from phys2bids import bids
 from phys2bids.bids import UNIT_ALIASES
@@ -12,13 +12,17 @@ from phys2bids.bids import UNIT_ALIASES
 def test_bidsify_units():
     # Add a dictionary of test possibilities
     unit_tests = {
-                  # test unit with standard prefix
-                  'centik': 'cK', 'CENTIk': 'cK',
-                  # test unit with not standard prefix
-                  'matV': 'matV', 'BigV': 'BigV',
-                  # test unit that are not bids standard
-                  'mmHg': 'mmHg', 'mmlie': 'mmlie', 'MMLIE': 'MMLIE',
-                 }
+        # test unit with standard prefix
+        "centik": "cK",
+        "CENTIk": "cK",
+        # test unit with not standard prefix
+        "matV": "matV",
+        "BigV": "BigV",
+        # test unit that are not bids standard
+        "mmHg": "mmHg",
+        "mmlie": "mmlie",
+        "MMLIE": "MMLIE",
+    }
     # Actually test
     for unit_key in unit_tests.keys():
         assert bids.bidsify_units(unit_key) == unit_tests[unit_key]
@@ -27,114 +31,119 @@ def test_bidsify_units():
         assert bids.bidsify_units(unit_key) == bids.UNIT_ALIASES[unit_key]
 
 
-@pytest.mark.parametrize('test_sub', ['SBJ01', 'sub-006', '006'])
-@pytest.mark.parametrize('test_ses', ['', 'S05', 'ses-42', '42'])
+@pytest.mark.parametrize("test_sub", ["SBJ01", "sub-006", "006"])
+@pytest.mark.parametrize("test_ses", ["", "S05", "ses-42", "42"])
 def test_use_heuristic(tmpdir, test_sub, test_ses):
-    test_heur_path = resource_filename('phys2bids', 'heuristics')
-    test_heur_file = 'heur_test_acq.py'
+    test_heur_path = resource_filename("phys2bids", "heuristics")
+    test_heur_file = "heur_test_acq.py"
     test_full_heur_path = os.path.join(test_heur_path, test_heur_file)
-    test_input_path = resource_filename('phys2bids', 'tests/data')
-    test_input_file = 'Test_belt_pulse_samefreq.acq'
+    test_input_path = resource_filename("phys2bids", "tests/data")
+    test_input_file = "Test_belt_pulse_samefreq.acq"
     test_full_input_path = os.path.join(test_input_path, test_input_file)
     test_outdir = tmpdir
-    test_record_label = 'test'
+    test_record_label = "test"
 
-    heur_path = bids.use_heuristic(test_full_heur_path, test_sub, test_ses,
-                                   test_full_input_path, test_outdir,
-                                   record_label=test_record_label)
+    heur_path = bids.use_heuristic(
+        test_full_heur_path,
+        test_sub,
+        test_ses,
+        test_full_input_path,
+        test_outdir,
+        record_label=test_record_label,
+    )
 
-    if test_sub[:4] == 'sub-':
+    if test_sub[:4] == "sub-":
         test_sub = test_sub[4:]
 
-    test_result_path = (f'{tmpdir}/sub-{test_sub}')
-    test_result_name = (f'sub-{test_sub}')
+    test_result_path = f"{tmpdir}/sub-{test_sub}"
+    test_result_name = f"sub-{test_sub}"
 
-    if test_ses[:4] == 'ses-':
+    if test_ses[:4] == "ses-":
         test_ses = test_ses[4:]
 
     if test_ses:
-        test_result_path = (f'{test_result_path}/ses-{test_ses}')
-        test_result_name = (f'{test_result_name}_ses-{test_ses}')
+        test_result_path = f"{test_result_path}/ses-{test_ses}"
+        test_result_name = f"{test_result_name}_ses-{test_ses}"
 
-    test_result = (f'{test_result_path}/func/{test_result_name}'
-                   f'_task-test_rec-biopac_run-01_recording-test_physio')
+    test_result = (
+        f"{test_result_path}/func/{test_result_name}"
+        f"_task-test_rec-biopac_run-01_recording-test_physio"
+    )
 
     assert os.path.normpath(test_result) == os.path.normpath(str(heur_path))
 
 
-@pytest.mark.parametrize('outdir', '.')
+@pytest.mark.parametrize("outdir", ".")
 def test_README_file(outdir):
     bids.readme_file(outdir)
     assert os.path.join(outdir, "README")
     os.remove(os.path.join(outdir, "README"))
 
 
-@pytest.mark.parametrize('outdir', '.')
+@pytest.mark.parametrize("outdir", ".")
 def test_dataset_description_file(outdir):
     bids.dataset_description_file(outdir)
     assert os.path.join(outdir, "dataset_description.json")
     os.remove(os.path.join(outdir, "dataset_description.json"))
 
 
-@pytest.mark.parametrize('outdir', '.')
+@pytest.mark.parametrize("outdir", ".")
 def test_participants_file(outdir):
 
     # Checks first condition in line 198
-    test_sub = '001'
-    test_sub_no_yml = '002'
-    test_missing_sub = '003'
-    test_yaml_path = os.path.join(outdir, 'test.yml')
+    test_sub = "001"
+    test_sub_no_yml = "002"
+    test_missing_sub = "003"
+    test_yaml_path = os.path.join(outdir, "test.yml")
 
     # Populate yaml file
-    data = dict(participant=dict(
-                participant_id=f'sub-{test_sub}',
-                age='25',
-                sex='m',
-                handedness='r'))
+    data = dict(
+        participant=dict(participant_id=f"sub-{test_sub}", age="25", sex="m", handedness="r")
+    )
 
-    test_header = ['participant_id', 'age', 'sex', 'handedness']
-    test_data = [f'sub-{test_sub}', '25', 'm', 'r']
-    test_na = [f'sub-{test_sub_no_yml}', 'n/a', 'n/a', 'n/a']
-    test_missing = [f'sub-{test_missing_sub}', 'n/a', 'n/a', 'n/a']
+    test_header = ["participant_id", "age", "sex", "handedness"]
+    test_data = [f"sub-{test_sub}", "25", "m", "r"]
+    test_na = [f"sub-{test_sub_no_yml}", "n/a", "n/a", "n/a"]
+    test_missing = [f"sub-{test_missing_sub}", "n/a", "n/a", "n/a"]
     test_list = [test_header, test_data]
     test_no_yml = [test_header, test_data, test_na]
     test_missing_list = [test_header, test_data, test_na, test_missing]
 
     # Checks validity of tsv lines when yml file is given
-    with open(test_yaml_path, 'w') as outfile:
+    with open(test_yaml_path, "w") as outfile:
         yaml.dump(data, outfile, default_flow_style=False)
 
     bids.participants_file(outdir, test_yaml_path, test_sub)
 
     counter = 0
-    with open(os.path.join(outdir, 'participants.tsv')) as pf:
+    with open(os.path.join(outdir, "participants.tsv")) as pf:
         tsvreader = reader(pf, delimiter="\t")
         for line in tsvreader:
             assert line == test_list[counter]
             counter += 1
 
     # Checks when no yml file is given
-    bids.participants_file(outdir=outdir, yml='', sub=test_sub_no_yml)
+    bids.participants_file(outdir=outdir, yml="", sub=test_sub_no_yml)
     counter = 0
-    with open(os.path.join(outdir, 'participants.tsv')) as pf:
+    with open(os.path.join(outdir, "participants.tsv")) as pf:
         tsvreader = reader(pf, delimiter="\t")
         for line in tsvreader:
             assert line == test_no_yml[counter]
             counter += 1
 
     # Checks validity of tsv lines when file exists but no line for Subject
-    bids.participants_file(outdir=outdir, yml='', sub=test_missing_sub)
+    bids.participants_file(outdir=outdir, yml="", sub=test_missing_sub)
     counter = 0
-    with open(os.path.join(outdir, 'participants.tsv')) as pf:
+    with open(os.path.join(outdir, "participants.tsv")) as pf:
         tsvreader = reader(pf, delimiter="\t")
         for line in tsvreader:
             assert line == test_missing_list[counter]
             counter += 1
 
     # Test that subject from previous check is already there
-    bids.participants_file(outdir=outdir, yml='', sub=test_missing_sub)
+    bids.participants_file(outdir=outdir, yml="", sub=test_missing_sub)
     counter = 0
-    with open(os.path.join(outdir, 'participants.tsv')) as pf:
+    with open(os.path.join(outdir, "participants.tsv")) as pf:
         tsvreader = reader(pf, delimiter="\t")
         for line in tsvreader:
             assert line == test_missing_list[counter]

--- a/phys2bids/tests/test_integration.py
+++ b/phys2bids/tests/test_integration.py
@@ -236,7 +236,6 @@ def test_integration_heuristic(skip_integration, multifreq_lab_file):
 
 
 def test_integration_multirun(skip_integration, multi_run_file):
-
     if skip_integration:
         pytest.skip("Skipping integration test")
 

--- a/phys2bids/tests/test_integration.py
+++ b/phys2bids/tests/test_integration.py
@@ -6,17 +6,16 @@ import shutil
 import subprocess
 from os import remove
 from os.path import isfile, join, split
-from pkg_resources import resource_filename
 
 import pytest
+from pkg_resources import resource_filename
 
 from phys2bids._version import get_versions
 from phys2bids.phys2bids import phys2bids
 
 
 def check_string(str_container, str_to_find, str_expected, is_num=True):
-    idx = [log_idx for log_idx, log_str in enumerate(
-                      str_container) if str_to_find in log_str]
+    idx = [log_idx for log_idx, log_str in enumerate(str_container) if str_to_find in log_str]
     str_found = str_container[idx[0]]
     if is_num:
         num_found = re.findall(r"[-+]?\d*\.\d+|\d+", str_found)
@@ -31,52 +30,65 @@ def test_integration_acq(skip_integration, samefreq_full_acq_file):
     """
 
     if skip_integration:
-        pytest.skip('Skipping integration test')
+        pytest.skip("Skipping integration test")
 
     test_path, test_filename = split(samefreq_full_acq_file)
     test_chtrig = 3
-    conversion_path = join(test_path, 'code', 'conversion')
+    conversion_path = join(test_path, "code", "conversion")
 
-    phys2bids(filename=test_filename, indir=test_path, outdir=test_path,
-              chtrig=test_chtrig, num_timepoints_expected=60, tr=1.5)
+    phys2bids(
+        filename=test_filename,
+        indir=test_path,
+        outdir=test_path,
+        chtrig=test_chtrig,
+        num_timepoints_expected=60,
+        tr=1.5,
+    )
 
     # Check that files are generated
-    for suffix in ['.json', '.tsv.gz']:
-        assert isfile(join(test_path, 'Test_belt_pulse_samefreq' + suffix))
+    for suffix in [".json", ".tsv.gz"]:
+        assert isfile(join(test_path, "Test_belt_pulse_samefreq" + suffix))
 
     # Check files in extra are generated
-    for suffix in ['.log']:
-        assert isfile(join(conversion_path, 'Test_belt_pulse_samefreq' + suffix))
+    for suffix in [".log"]:
+        assert isfile(join(conversion_path, "Test_belt_pulse_samefreq" + suffix))
 
     # Read log file (note that this file is not the logger file)
-    with open(join(conversion_path, 'Test_belt_pulse_samefreq.log')) as log_info:
+    with open(join(conversion_path, "Test_belt_pulse_samefreq.log")) as log_info:
         log_info = log_info.readlines()
 
     # Check timepoints expected
-    assert check_string(log_info, 'Timepoints expected', '60')
+    assert check_string(log_info, "Timepoints expected", "60")
     # Check timepoints found
-    assert check_string(log_info, 'Timepoints found', '60')
+    assert check_string(log_info, "Timepoints found", "60")
     # Check sampling frequency
-    assert check_string(log_info, 'Sampling Frequency', '10000.0')
+    assert check_string(log_info, "Sampling Frequency", "10000.0")
     # Check sampling started
-    assert check_string(log_info, 'Sampling started', '10.4251')
+    assert check_string(log_info, "Sampling started", "10.4251")
     # Check start time
-    assert check_string(log_info, 'first trigger', 'Time 0', is_num=False)
+    assert check_string(log_info, "first trigger", "Time 0", is_num=False)
 
     # Checks json file
-    with open(join(test_path, 'Test_belt_pulse_samefreq.json')) as json_file:
+    with open(join(test_path, "Test_belt_pulse_samefreq.json")) as json_file:
         json_data = json.load(json_file)
 
     # Compares values in json file with ground truth
-    assert math.isclose(json_data['SamplingFrequency'], 10000.0)
-    assert math.isclose(json_data['StartTime'], 10.4251)
-    assert json_data['Columns'] == ['time', 'RESP - RSP100C', 'PULSE - Custom, DA100C',
-                                    'MR TRIGGER - Custom, HLT100C - A 5', 'PPG100C', 'CO2', 'O2']
+    assert math.isclose(json_data["SamplingFrequency"], 10000.0)
+    assert math.isclose(json_data["StartTime"], 10.4251)
+    assert json_data["Columns"] == [
+        "time",
+        "RESP - RSP100C",
+        "PULSE - Custom, DA100C",
+        "MR TRIGGER - Custom, HLT100C - A 5",
+        "PPG100C",
+        "CO2",
+        "O2",
+    ]
 
     # Remove generated files
-    for filename in glob.glob(join(conversion_path, 'phys2bids*')):
+    for filename in glob.glob(join(conversion_path, "phys2bids*")):
         remove(filename)
-    for filename in glob.glob(join(test_path, 'Test_belt_pulse_samefreq*')):
+    for filename in glob.glob(join(test_path, "Test_belt_pulse_samefreq*")):
         remove(filename)
     shutil.rmtree(conversion_path)
 
@@ -87,155 +99,178 @@ def test_integration_heuristic(skip_integration, multifreq_lab_file):
     """
 
     if skip_integration:
-        pytest.skip('Skipping integration test')
+        pytest.skip("Skipping integration test")
 
     test_path, test_filename = split(multifreq_lab_file)
     test_full_path = join(test_path, test_filename)
     test_chtrig = 1
     test_outdir = test_path
-    conversion_path = join(test_path, 'code', 'conversion')
+    conversion_path = join(test_path, "code", "conversion")
     test_ntp = 30
     test_tr = 1.2
     test_thr = 0.735
-    heur_path = resource_filename('phys2bids', 'heuristics')
-    test_heur = join(heur_path, 'heur_test_multifreq.py')
+    heur_path = resource_filename("phys2bids", "heuristics")
+    test_heur = join(heur_path, "heur_test_multifreq.py")
 
     # Move into folder
-    subprocess.run(f'cd {test_path}', shell=True, check=True)
+    subprocess.run(f"cd {test_path}", shell=True, check=True)
     # Phys2bids call through terminal
-    command_str = (f'phys2bids -in {test_full_path} ',
-                   f'-chtrig {test_chtrig} -outdir {test_outdir} ',
-                   f'-tr {test_tr} -ntp {test_ntp} -thr {test_thr} ',
-                   f'-sub 006 -ses 01 -heur {test_heur}')
-    command_str = ''.join(command_str)
+    command_str = (
+        f"phys2bids -in {test_full_path} ",
+        f"-chtrig {test_chtrig} -outdir {test_outdir} ",
+        f"-tr {test_tr} -ntp {test_ntp} -thr {test_thr} ",
+        f"-sub 006 -ses 01 -heur {test_heur}",
+    )
+    command_str = "".join(command_str)
     subprocess.run(command_str, shell=True, check=True)
 
     # Check that call.sh is generated
-    assert isfile(join(conversion_path, 'call.sh'))
+    assert isfile(join(conversion_path, "call.sh"))
 
     # Read logger file
-    logger_file = glob.glob(join(conversion_path, '*phys2bids*'))[0]
+    logger_file = glob.glob(join(conversion_path, "*phys2bids*"))[0]
     with open(logger_file) as logger_info:
         logger_info = logger_info.readlines()
 
     # Get version info
     current_version = get_versions()
-    assert check_string(logger_info, 'phys2bids version', current_version['version'], is_num=False)
+    assert check_string(logger_info, "phys2bids version", current_version["version"], is_num=False)
 
-    assert check_string(logger_info, '01. Trigger; sampled at', '1000.0')
+    assert check_string(logger_info, "01. Trigger; sampled at", "1000.0")
     # Should be 500.0 for sampling, but new faster multifreq version does not detect it.
-    assert check_string(logger_info, '04. Belt; sampled at', '1000.0')
+    assert check_string(logger_info, "04. Belt; sampled at", "1000.0")
 
     # Check that files are generated in conversion path
     # There should be a 500 too, but labchart export doesn't work well.
-    for freq in ['40', '100', '1000']:
-        assert isfile(join(conversion_path,
-                           'sub-006_ses-01_task-test_rec-biopac_run-01_'
-                           f'recording-{freq}Hz_physio.log'))
+    for freq in ["40", "100", "1000"]:
+        assert isfile(
+            join(
+                conversion_path,
+                "sub-006_ses-01_task-test_rec-biopac_run-01_" f"recording-{freq}Hz_physio.log",
+            )
+        )
     # assert isfile(join(conversion_path,
     #                    'Test1_multifreq_onescan_sub-006_ses-01_trigger_time.png'))
-    assert isfile(join(conversion_path, 'Test1_multifreq_onescan.png'))
-    assert isfile(join(conversion_path, 'heur_test_multifreq.py'))
-    test_path_output = join(test_path, 'sub-006/ses-01/func')
+    assert isfile(join(conversion_path, "Test1_multifreq_onescan.png"))
+    assert isfile(join(conversion_path, "heur_test_multifreq.py"))
+    test_path_output = join(test_path, "sub-006/ses-01/func")
 
     # Check that files are generated
-    base_filename = 'sub-006_ses-01_task-test_rec-biopac_run-01_recording-'
-    for suffix in ['.json', '.tsv.gz']:
+    base_filename = "sub-006_ses-01_task-test_rec-biopac_run-01_recording-"
+    for suffix in [".json", ".tsv.gz"]:
         # There should be a 500 too, but labchart export doesn't work well.
-        for freq in ['40', '100', '1000']:
-            assert isfile(join(test_path_output,
-                               f'{base_filename}{freq}Hz_physio{suffix}'))
+        for freq in ["40", "100", "1000"]:
+            assert isfile(join(test_path_output, f"{base_filename}{freq}Hz_physio{suffix}"))
 
     # ##### Checks for 40 Hz files
     # Read log file (note that this file is not the logger file)
-    log_filename = 'sub-006_ses-01_task-test_rec-biopac_run-01_recording-40Hz_physio.log'
+    log_filename = "sub-006_ses-01_task-test_rec-biopac_run-01_recording-40Hz_physio.log"
     with open(join(conversion_path, log_filename)) as log_info:
         log_info = log_info.readlines()
 
     # Check timepoints expected
-    assert check_string(log_info, 'Timepoints expected', '30')
+    assert check_string(log_info, "Timepoints expected", "30")
     # Check timepoints found
-    assert check_string(log_info, 'Timepoints found', '30')
+    assert check_string(log_info, "Timepoints found", "30")
     # Check sampling frequency
-    assert check_string(log_info, 'Sampling Frequency', '40.0')
+    assert check_string(log_info, "Sampling Frequency", "40.0")
     # Check sampling started
-    assert check_string(log_info, 'Sampling started', '3.6960')
+    assert check_string(log_info, "Sampling started", "3.6960")
     # Check first trigger
-    assert check_string(log_info, 'first trigger', 'Time 0', is_num=False)
+    assert check_string(log_info, "first trigger", "Time 0", is_num=False)
 
     # Checks json file
-    json_filename = 'sub-006_ses-01_task-test_rec-biopac_run-01_recording-40Hz_physio.json'
+    json_filename = "sub-006_ses-01_task-test_rec-biopac_run-01_recording-40Hz_physio.json"
     with open(join(test_path_output, json_filename)) as json_file:
         json_data = json.load(json_file)
 
     # Compares values in json file with ground truth
-    assert math.isclose(json_data['SamplingFrequency'], 40.0,)
-    assert math.isclose(json_data['StartTime'], 3.6960,)
-    assert json_data['Columns'] == ['time', 'Trigger', 'O2']
+    assert math.isclose(
+        json_data["SamplingFrequency"],
+        40.0,
+    )
+    assert math.isclose(
+        json_data["StartTime"],
+        3.6960,
+    )
+    assert json_data["Columns"] == ["time", "Trigger", "O2"]
 
     # ##### Checks for 100 Hz files
     # Read log file (note that this file is not the logger file)
-    log_filename = 'sub-006_ses-01_task-test_rec-biopac_run-01_recording-100Hz_physio.log'
+    log_filename = "sub-006_ses-01_task-test_rec-biopac_run-01_recording-100Hz_physio.log"
     with open(join(conversion_path, log_filename)) as log_info:
         log_info = log_info.readlines()
 
     # Check timepoints expected
-    assert check_string(log_info, 'Timepoints expected', '30')
+    assert check_string(log_info, "Timepoints expected", "30")
     # Check timepoints found
-    assert check_string(log_info, 'Timepoints found', '30')
+    assert check_string(log_info, "Timepoints found", "30")
     # Check sampling frequency
-    assert check_string(log_info, 'Sampling Frequency', '100.0')
+    assert check_string(log_info, "Sampling Frequency", "100.0")
     # Check sampling started
-    assert check_string(log_info, 'Sampling started', '3.6960')
+    assert check_string(log_info, "Sampling started", "3.6960")
     # Check first trigger
-    assert check_string(log_info, 'first trigger', 'Time 0', is_num=False)
+    assert check_string(log_info, "first trigger", "Time 0", is_num=False)
 
     # Checks json file
-    json_filename = 'sub-006_ses-01_task-test_rec-biopac_run-01_recording-100Hz_physio.json'
+    json_filename = "sub-006_ses-01_task-test_rec-biopac_run-01_recording-100Hz_physio.json"
     with open(join(test_path_output, json_filename)) as json_file:
         json_data = json.load(json_file)
 
     # Compares values in json file with ground truth
-    assert math.isclose(json_data['SamplingFrequency'], 100.0,)
-    assert math.isclose(json_data['StartTime'], 3.6960,)
-    assert json_data['Columns'] == ['time', 'Trigger', 'CO2']
+    assert math.isclose(
+        json_data["SamplingFrequency"],
+        100.0,
+    )
+    assert math.isclose(
+        json_data["StartTime"],
+        3.6960,
+    )
+    assert json_data["Columns"] == ["time", "Trigger", "CO2"]
 
     # Remove generated files
     shutil.rmtree(test_path_output)
     shutil.rmtree(conversion_path)
-    for filename in glob.glob(join(test_path, 'Test1_multifreq_onescan*')):
+    for filename in glob.glob(join(test_path, "Test1_multifreq_onescan*")):
         remove(filename)
 
 
 def test_integration_multirun(skip_integration, multi_run_file):
 
     if skip_integration:
-        pytest.skip('Skipping integration test')
+        pytest.skip("Skipping integration test")
 
     test_path, test_filename = split(multi_run_file)
     test_chtrig = 1
-    conversion_path = join(test_path, 'code', 'conversion')
+    conversion_path = join(test_path, "code", "conversion")
 
-    phys2bids(filename=test_filename, indir=test_path, outdir=test_path,
-              chtrig=test_chtrig, num_timepoints_expected=[534, 513], tr=[1.2, 1.2])
+    phys2bids(
+        filename=test_filename,
+        indir=test_path,
+        outdir=test_path,
+        chtrig=test_chtrig,
+        num_timepoints_expected=[534, 513],
+        tr=[1.2, 1.2],
+    )
 
     # Check that files are generated in outdir
-    base_filename = 'Test2_samefreq_TWOscans_'
-    for suffix in ['.json', '.tsv.gz']:
-        for run in ['01', '02']:
-            assert isfile(join(test_path, f'{base_filename}{run}{suffix}'))
+    base_filename = "Test2_samefreq_TWOscans_"
+    for suffix in [".json", ".tsv.gz"]:
+        for run in ["01", "02"]:
+            assert isfile(join(test_path, f"{base_filename}{run}{suffix}"))
 
-    assert isfile(join(test_path, 'Test2_samefreq_TWOscans.txt'))
+    assert isfile(join(test_path, "Test2_samefreq_TWOscans.txt"))
 
     # Check that files are generated in conversion_path
-    for run in ['01', '02']:
-        assert isfile(join(conversion_path, f'Test2_samefreq_TWOscans_{run}.log'))
+    for run in ["01", "02"]:
+        assert isfile(join(conversion_path, f"Test2_samefreq_TWOscans_{run}.log"))
 
     # Check that plots are generated in conversion_path
     # base_filename = 'Test2_samefreq_TWOscans_'
     # for run in ['1', '2']:
     #     assert isfile(join(conversion_path, f'Test2_samefreq_TWOscans_{run}_trigger_time.png'))
-    assert isfile(join(conversion_path, 'Test2_samefreq_TWOscans.png'))
+    assert isfile(join(conversion_path, "Test2_samefreq_TWOscans.png"))
+
 
 def test_integration_gep_onefile(skip_integration, ge_one_gep_file):
     """
@@ -244,49 +279,49 @@ def test_integration_gep_onefile(skip_integration, ge_one_gep_file):
     """
 
     if skip_integration:
-        pytest.skip('Skipping integration test')
+        pytest.skip("Skipping integration test")
 
     test_path, test_filename = split(ge_one_gep_file)
-    conversion_path = join(test_path, 'code', 'conversion')
+    conversion_path = join(test_path, "code", "conversion")
 
     phys2bids(filename=test_filename, indir=test_path, outdir=test_path)
 
     # Check that files are generated
-    for suffix in ['.json', '.tsv.gz']:
+    for suffix in [".json", ".tsv.gz"]:
         assert isfile(join(test_path, test_filename[:-4] + suffix))
 
     # Check files in extra are generated
-    for suffix in ['.log']:
+    for suffix in [".log"]:
         assert isfile(join(conversion_path, test_filename[:-4] + suffix))
 
     # Read log file (note that this file is not the logger file)
-    with open(join(conversion_path, test_filename[:-4] + '.log')) as log_info:
+    with open(join(conversion_path, test_filename[:-4] + ".log")) as log_info:
         log_info = log_info.readlines()
 
     # Check timepoints expected
-    assert check_string(log_info, 'Timepoints expected', 'None', is_num=False)
+    assert check_string(log_info, "Timepoints expected", "None", is_num=False)
     # Check timepoints found
-    assert check_string(log_info, 'Timepoints found', 'None', is_num=False)
+    assert check_string(log_info, "Timepoints found", "None", is_num=False)
     # Check sampling frequency
-    assert check_string(log_info, 'Sampling Frequency', '100')
+    assert check_string(log_info, "Sampling Frequency", "100")
     # Check sampling started
-    assert check_string(log_info, 'Sampling started', '30.0000')
+    assert check_string(log_info, "Sampling started", "30.0000")
     # Check start time
-    assert check_string(log_info, 'first trigger', 'Time 0', is_num=False)
+    assert check_string(log_info, "first trigger", "Time 0", is_num=False)
 
     # Checks json file
-    with open(join(test_path, test_filename[:-4] + '.json')) as json_file:
+    with open(join(test_path, test_filename[:-4] + ".json")) as json_file:
         json_data = json.load(json_file)
 
     # Compares values in json file with ground truth
-    assert math.isclose(json_data['SamplingFrequency'], 100)
-    assert math.isclose(json_data['StartTime'], 30.0)
-    assert json_data['Columns'] == ['time', 'trigger', 'cardiac']
+    assert math.isclose(json_data["SamplingFrequency"], 100)
+    assert math.isclose(json_data["StartTime"], 30.0)
+    assert json_data["Columns"] == ["time", "trigger", "cardiac"]
 
     # Remove generated files
-    for filename in glob.glob(join(conversion_path, 'phys2bids*')):
+    for filename in glob.glob(join(conversion_path, "phys2bids*")):
         remove(filename)
-    for filename in glob.glob(join(test_path, test_filename+'*')):
+    for filename in glob.glob(join(test_path, test_filename + "*")):
         remove(filename)
     shutil.rmtree(conversion_path)
 
@@ -298,50 +333,50 @@ def test_integration_gep_multifile(skip_integration, ge_two_gep_files_ppg):
     """
 
     if skip_integration:
-        pytest.skip('Skipping integration test')
+        pytest.skip("Skipping integration test")
 
     test_path, test_filename = split(ge_two_gep_files_ppg)
-    conversion_path = join(test_path, 'code', 'conversion')
+    conversion_path = join(test_path, "code", "conversion")
 
     phys2bids(filename=test_filename, indir=test_path, outdir=test_path)
 
     # Check that files are generated
-    for suffix in ['.json', '.tsv.gz']:
-        assert isfile(join(test_path, test_filename[:-4] + '_100Hz' + suffix))
-        assert isfile(join(test_path, test_filename[:-4] + '_25Hz' + suffix))
+    for suffix in [".json", ".tsv.gz"]:
+        assert isfile(join(test_path, test_filename[:-4] + "_100Hz" + suffix))
+        assert isfile(join(test_path, test_filename[:-4] + "_25Hz" + suffix))
 
     # Check files in extra are generated
-    for suffix in ['.log']:
-        assert isfile(join(conversion_path, test_filename[:-4] + '_100Hz' + suffix))
-        assert isfile(join(conversion_path, test_filename[:-4] + '_25Hz' + suffix))
+    for suffix in [".log"]:
+        assert isfile(join(conversion_path, test_filename[:-4] + "_100Hz" + suffix))
+        assert isfile(join(conversion_path, test_filename[:-4] + "_25Hz" + suffix))
 
     # Read log file (note that this file is not the logger file)
-    with open(join(conversion_path, test_filename[:-4] + '_100Hz.log')) as log_info:
+    with open(join(conversion_path, test_filename[:-4] + "_100Hz.log")) as log_info:
         log_info = log_info.readlines()
 
     # Check timepoints expected
-    assert check_string(log_info, 'Timepoints expected', 'None', is_num=False)
+    assert check_string(log_info, "Timepoints expected", "None", is_num=False)
     # Check timepoints found
-    assert check_string(log_info, 'Timepoints found', 'None', is_num=False)
+    assert check_string(log_info, "Timepoints found", "None", is_num=False)
     # Check sampling frequency
-    assert check_string(log_info, 'Sampling Frequency', '100')
+    assert check_string(log_info, "Sampling Frequency", "100")
     # Check sampling started
-    assert check_string(log_info, 'Sampling started', '30.0000')
+    assert check_string(log_info, "Sampling started", "30.0000")
     # Check start time
-    assert check_string(log_info, 'first trigger', 'Time 0', is_num=False)
+    assert check_string(log_info, "first trigger", "Time 0", is_num=False)
 
     # Checks json file
-    with open(join(test_path, test_filename[:-4] + '_100Hz.json')) as json_file:
+    with open(join(test_path, test_filename[:-4] + "_100Hz.json")) as json_file:
         json_data = json.load(json_file)
 
     # Compares values in json file with ground truth
-    assert math.isclose(json_data['SamplingFrequency'], 100)
-    assert math.isclose(json_data['StartTime'], 30.0)
-    assert json_data['Columns'] == ['time', 'trigger', 'cardiac']
+    assert math.isclose(json_data["SamplingFrequency"], 100)
+    assert math.isclose(json_data["StartTime"], 30.0)
+    assert json_data["Columns"] == ["time", "trigger", "cardiac"]
 
     # Remove generated files
-    for filename in glob.glob(join(conversion_path, 'phys2bids*')):
+    for filename in glob.glob(join(conversion_path, "phys2bids*")):
         remove(filename)
-    for filename in glob.glob(join(test_path, test_filename+'*')):
+    for filename in glob.glob(join(test_path, test_filename + "*")):
         remove(filename)
     shutil.rmtree(conversion_path)

--- a/phys2bids/tests/test_phys2bids.py
+++ b/phys2bids/tests/test_phys2bids.py
@@ -4,41 +4,48 @@ Tests phys2bids.py
 
 import json
 import os
+
 from pytest import raises
 
 from phys2bids import phys2bids
 
 
 def test_print_summary(tmpdir):
-    test_filename = 'input.txt'
-    test_ntp_expected = [10, ]
+    test_filename = "input.txt"
+    test_ntp_expected = [
+        10,
+    ]
     test_ntp_found = 5
     test_samp_freq = 0.2
     test_time_offset = 0.8
-    test_outfile = tmpdir.join('summary')
-    test_outfile_log = tmpdir.join('summary.log')
+    test_outfile = tmpdir.join("summary")
+    test_outfile_log = tmpdir.join("summary.log")
 
-    phys2bids.print_summary(test_filename, test_ntp_expected, test_ntp_found,
-                            test_samp_freq, test_time_offset, str(test_outfile))
+    phys2bids.print_summary(
+        test_filename,
+        test_ntp_expected,
+        test_ntp_found,
+        test_samp_freq,
+        test_time_offset,
+        str(test_outfile),
+    )
 
     assert os.path.isfile(str(test_outfile_log))
 
 
 def test_print_json(tmpdir):
-    test_outfile = tmpdir.join('json_test')
-    test_outfile_json = tmpdir.join('json_test.json')
+    test_outfile = tmpdir.join("json_test")
+    test_outfile_json = tmpdir.join("json_test.json")
     test_samp_freq = 0.1
     test_time_offset = -0.5
-    test_ch_name = 'foo'
+    test_ch_name = "foo"
 
     phys2bids.print_json(str(test_outfile), test_samp_freq, test_time_offset, test_ch_name)
 
     assert os.path.isfile(test_outfile_json)
 
-    test_json_data = dict(SamplingFrequency=0.1,
-                          StartTime=0.5,
-                          Columns='foo')
-    with open(test_outfile_json, 'r') as src:
+    test_json_data = dict(SamplingFrequency=0.1, StartTime=0.5, Columns="foo")
+    with open(test_outfile_json, "r") as src:
         loaded_data = json.load(src)
 
     assert test_json_data == loaded_data
@@ -48,14 +55,26 @@ def test_raise_exception(samefreq_full_acq_file):
     test_path, test_filename = os.path.split(samefreq_full_acq_file)
     with raises(Exception) as errorinfo:
         phys2bids.phys2bids(filename=test_filename, indir=test_path, outdir=test_path, chtrig=-1)
-    assert 'Wrong trigger' in str(errorinfo.value)
+    assert "Wrong trigger" in str(errorinfo.value)
 
     with raises(Exception) as errorinfo:
-        phys2bids.phys2bids(filename=test_filename, num_timepoints_expected=[70], tr=[1.3, 2],
-                            indir=test_path, outdir=test_path, chtrig=3)
+        phys2bids.phys2bids(
+            filename=test_filename,
+            num_timepoints_expected=[70],
+            tr=[1.3, 2],
+            indir=test_path,
+            outdir=test_path,
+            chtrig=3,
+        )
     assert "doesn't match" in str(errorinfo.value)
 
     with raises(Exception) as errorinfo:
-        phys2bids.phys2bids(filename=test_filename, num_timepoints_expected=[20, 300], chtrig=3,
-                            tr=1.5, indir=test_path, outdir=test_path)
-    assert 'stop now' in str(errorinfo.value)
+        phys2bids.phys2bids(
+            filename=test_filename,
+            num_timepoints_expected=[20, 300],
+            chtrig=3,
+            tr=1.5,
+            indir=test_path,
+            outdir=test_path,
+        )
+    assert "stop now" in str(errorinfo.value)

--- a/phys2bids/tests/test_physio_obj.py
+++ b/phys2bids/tests/test_physio_obj.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 from pytest import raises
+
 from phys2bids import physio_obj as po
 
 
@@ -21,7 +22,7 @@ def test_is_valid():
 
     with raises(AttributeError) as errorinfo:
         valid_output = po.is_valid(test_array, int)
-    assert 'The given variable is not a' in str(errorinfo.value)
+    assert "The given variable is not a" in str(errorinfo.value)
 
 
 # Tests has_size
@@ -43,12 +44,12 @@ def test_has_size():
 
 def test_are_equal():
     """Test are_equal ."""
-    test_string = 'So Long, and Thanks for All the Fish'
+    test_string = "So Long, and Thanks for All the Fish"
     test_time = np.array([0, 1, 1, 2, 3, 5, 8, 13])
     test_trigger = np.array([0, 1, 0, 0, 0, 0, 0, 0])
 
     class C(object):
-        c = 'c'
+        c = "c"
 
     c1 = C()
     c1.ts = [test_time, test_trigger]
@@ -60,15 +61,14 @@ def test_are_equal():
     test_twice = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
     test_timeseries = [test_time, test_trigger, test_half, test_twice]
     test_freq = [1, 1, 0.5, 2]
-    test_chn_name = ['time', 'trigger', 'half', 'twice']
-    test_units = ['s', 'V', 'V', 'V']
+    test_chn_name = ["time", "trigger", "half", "twice"]
+    test_units = ["s", "V", "V", "V"]
     test_chtrig = 1
 
-    phys_in = po.BlueprintInput(test_timeseries, test_freq, test_chn_name,
-                                test_units, test_chtrig)
-    phys_out = po.BlueprintInput([test_trigger, test_half, test_twice],
-                                 test_freq, test_chn_name,
-                                 test_units, test_chtrig)
+    phys_in = po.BlueprintInput(test_timeseries, test_freq, test_chn_name, test_units, test_chtrig)
+    phys_out = po.BlueprintInput(
+        [test_trigger, test_half, test_twice], test_freq, test_chn_name, test_units, test_chtrig
+    )
 
     assert po.are_equal(test_string, test_string)
     assert po.are_equal(c1, c1)
@@ -90,18 +90,19 @@ def test_BlueprintInput():
     test_chocolate = np.array([1, 0, 0, 1, 0, 0, 1, 0])
     test_timeseries = [test_time, test_trigger, test_chocolate]
     test_freq = [42.0, 3.14, 20.0]
-    test_chn_name = ['time', 'trigger', 'chocolate']
-    test_units = ['s', 's', 'sweetness']
+    test_chn_name = ["time", "trigger", "chocolate"]
+    test_units = ["s", "s", "sweetness"]
     test_chtrig = 1
     num_channnels = len(test_timeseries)
 
-    blueprint_in = po.BlueprintInput(test_timeseries, test_freq, test_chn_name,
-                                     test_units, test_chtrig)
+    blueprint_in = po.BlueprintInput(
+        test_timeseries, test_freq, test_chn_name, test_units, test_chtrig
+    )
 
     # Tests rename_channels
-    new_names = ['trigger', 'time', 'lindt']
+    new_names = ["trigger", "time", "lindt"]
     blueprint_in.rename_channels(new_names)
-    assert blueprint_in.ch_name == ['time', 'trigger', 'lindt']
+    assert blueprint_in.ch_name == ["time", "trigger", "lindt"]
 
     # Tests return_index
     test_index = blueprint_in.return_index(1)
@@ -133,7 +134,7 @@ def test_BlueprintInput():
 
     with raises(IndexError) as errorinfo:
         blueprint_in.__getitem__(1000)
-    assert 'out of bounds' in str(errorinfo.value)
+    assert "out of bounds" in str(errorinfo.value)
 
 
 def test_cta_time_interp():
@@ -142,12 +143,13 @@ def test_cta_time_interp():
     test_trigger = np.array([0, 1, 0, 0, 0, 0, 0, 0])
     test_timeseries = [test_time, test_trigger]
     test_freq = [42.0, 3.14]
-    test_chn_name = ['time', 'trigger']
-    test_units = ['s', 's']
+    test_chn_name = ["time", "trigger"]
+    test_units = ["s", "s"]
     test_chtrig = 1
 
-    blueprint_in = po.BlueprintInput(test_timeseries, test_freq, test_chn_name,
-                                     test_units, test_chtrig)
+    blueprint_in = po.BlueprintInput(
+        test_timeseries, test_freq, test_chn_name, test_units, test_chtrig
+    )
     # Test check_trigger_amount with time resampling
     blueprint_in.check_trigger_amount(thr=0.9, num_timepoints_expected=1)
     assert blueprint_in.num_timepoints_found == 1
@@ -164,18 +166,15 @@ def test_BlueprintInput_slice():
     test_twice = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
     test_timeseries = [test_time, test_trigger, test_half, test_twice]
     test_freq = [1, 1, 0.5, 2]
-    test_chn_name = ['time', 'trigger', 'half', 'twice']
-    test_units = ['s', 'V', 'V', 'V']
+    test_chn_name = ["time", "trigger", "half", "twice"]
+    test_units = ["s", "V", "V", "V"]
     test_chtrig = 1
 
-    phys_in = po.BlueprintInput(test_timeseries, test_freq, test_chn_name,
-                                test_units, test_chtrig)
+    phys_in = po.BlueprintInput(test_timeseries, test_freq, test_chn_name, test_units, test_chtrig)
 
-    phys_d = po.BlueprintInput(test_timeseries,
-                               test_freq,
-                               ['time', 'trigger', 'half', 'twice'],
-                               ['s', 'V', 'V', 'V'],
-                               1)
+    phys_d = po.BlueprintInput(
+        test_timeseries, test_freq, ["time", "trigger", "half", "twice"], ["s", "V", "V", "V"], 1
+    )
 
     phys_d.num_timepoints_found = None
     phys_d.thr = None
@@ -183,33 +182,41 @@ def test_BlueprintInput_slice():
     phys_d._time_resampled_to_trigger = None
 
     # Test all-comprehensive slice
-    assert phys_in[0:len(test_trigger)] == phys_d
+    assert phys_in[0 : len(test_trigger)] == phys_d
 
     # Test instantaneous slice first and last
-    phys_d.timeseries = [np.array([test_time[0]]),
-                         np.array([test_trigger[0]]),
-                         np.array([test_half[0]]),
-                         np.array([test_twice[0]])]
+    phys_d.timeseries = [
+        np.array([test_time[0]]),
+        np.array([test_trigger[0]]),
+        np.array([test_half[0]]),
+        np.array([test_twice[0]]),
+    ]
     assert phys_in[0] == phys_d
 
-    phys_d.timeseries = [np.array([test_time[-1]]),
-                         np.array([test_trigger[-1]]),
-                         np.array([test_half[-1]]),
-                         np.array([test_twice[-2]])]
+    phys_d.timeseries = [
+        np.array([test_time[-1]]),
+        np.array([test_trigger[-1]]),
+        np.array([test_half[-1]]),
+        np.array([test_twice[-2]]),
+    ]
     assert phys_in[-1] == phys_d
 
     # Test slice in the middle
-    phys_d.timeseries = [np.array(test_time[2:4]),
-                         np.array(test_trigger[2:4]),
-                         np.array(test_half[1:2]),
-                         np.array(test_twice[4:8])]
+    phys_d.timeseries = [
+        np.array(test_time[2:4]),
+        np.array(test_trigger[2:4]),
+        np.array(test_half[1:2]),
+        np.array(test_twice[4:8]),
+    ]
     assert phys_in[2:4] == phys_d
 
     # Test slice in the middle with steps
-    phys_d.timeseries = [np.array(test_time[1:4:2]),
-                         np.array(test_trigger[1:4:2]),
-                         np.array(test_half[0:2:1]),
-                         np.array(test_twice[4:8:4])]
+    phys_d.timeseries = [
+        np.array(test_time[1:4:2]),
+        np.array(test_trigger[1:4:2]),
+        np.array(test_half[0:2:1]),
+        np.array(test_twice[4:8:4]),
+    ]
     assert phys_in[1:4:2] == phys_d
 
 
@@ -219,13 +226,14 @@ def test_BlueprintOutput():
     test_chocolate = np.array([1, 0, 0, 1, 0, 0, 1, 0])
     test_timeseries = [test_time, test_trigger, test_chocolate]
     test_freq = [42.0, 3.14, 20.0]
-    test_chn_name = ['trigger', 'time', 'chocolate']
-    test_units = ['s', 's', 'sweetness']
+    test_chn_name = ["trigger", "time", "chocolate"]
+    test_units = ["s", "s", "sweetness"]
     test_chtrig = 1
     num_channnels = len(test_timeseries)
 
-    blueprint_in = po.BlueprintInput(test_timeseries, test_freq, test_chn_name,
-                                     test_units, test_chtrig)
+    blueprint_in = po.BlueprintInput(
+        test_timeseries, test_freq, test_chn_name, test_units, test_chtrig
+    )
 
     # Tests init_from_blueprint
     blueprint_out = po.BlueprintOutput.init_from_blueprint(blueprint_in)
@@ -237,15 +245,16 @@ def test_BlueprintOutput():
     assert blueprint_out.start_time == 0
 
     # Tests return_index
-    test_timeseries = np.array([[0, 1, 1, 2, 3, 5, 8, 13],
-                                [0, 1, 0, 0, 0, 0, 0, 0],
-                                [1, 0, 0, 1, 0, 0, 1, 0]]).T
+    test_timeseries = np.array(
+        [[0, 1, 1, 2, 3, 5, 8, 13], [0, 1, 0, 0, 0, 0, 0, 0], [1, 0, 0, 1, 0, 0, 1, 0]]
+    ).T
     test_freq = 42.0
-    test_chn_name = ['trigger', 'time', 'chocolate']
-    test_units = ['s', 's', 'sweetness']
+    test_chn_name = ["trigger", "time", "chocolate"]
+    test_units = ["s", "s", "sweetness"]
     num_channnels = test_timeseries.shape[1]
-    blueprint_out = po.BlueprintOutput(test_timeseries, test_freq, test_chn_name, test_units,
-                                       start_time)
+    blueprint_out = po.BlueprintOutput(
+        test_timeseries, test_freq, test_chn_name, test_units, start_time
+    )
     test_index = blueprint_out.return_index(1)
     assert (test_index[0] == test_trigger).all()
     assert test_index[1] == test_timeseries.shape[1]
@@ -271,26 +280,25 @@ def test_auto_trigger_selection_text(caplog):
     test_twice = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
     test_timeseries = [test_time, test_trigger, test_half, test_twice, test_twice, test_twice]
     test_freq = [1, 1, 0.5, 2, 2, 2]
-    test_chn_name = ['time', 'trigger', 'half', 'CO2', 'CO 2', 'strigose']
-    test_units = ['s', 'V', 'V', 'V', 'V', 'V']
+    test_chn_name = ["time", "trigger", "half", "CO2", "CO 2", "strigose"]
+    test_units = ["s", "V", "V", "V", "V", "V"]
 
     # test when trigger is not the name of the channel
     test_chtrig = 2
-    phys_in = po.BlueprintInput(test_timeseries, test_freq, test_chn_name,
-                                test_units, test_chtrig)
-    assert 'Trigger channel name is not' in caplog.text
+    phys_in = po.BlueprintInput(test_timeseries, test_freq, test_chn_name, test_units, test_chtrig)
+    assert "Trigger channel name is not" in caplog.text
 
     # test when trigger is 0 and that the trigger channel is recognized by name:
     test_chtrig = 0
-    phys_in = po.BlueprintInput(test_timeseries, test_freq, test_chn_name,
-                                test_units, test_chtrig)
+    phys_in = po.BlueprintInput(test_timeseries, test_freq, test_chn_name, test_units, test_chtrig)
     assert phys_in.trigger_idx == 1
     # test when no trigger is found
-    test_chn_name = ['time', 'trigger', 'TRIGGER', 'CO2', 'CO 2', 'strigose']
+    test_chn_name = ["time", "trigger", "TRIGGER", "CO2", "CO 2", "strigose"]
     with raises(Exception) as errorinfo:
-        phys_in = po.BlueprintInput(test_timeseries, test_freq, test_chn_name,
-                                    test_units, test_chtrig)
-        assert 'More than one possible trigger channel' in str(errorinfo.value)
+        phys_in = po.BlueprintInput(
+            test_timeseries, test_freq, test_chn_name, test_units, test_chtrig
+        )
+        assert "More than one possible trigger channel" in str(errorinfo.value)
 
 
 def test_auto_trigger_selection_time():
@@ -298,24 +306,23 @@ def test_auto_trigger_selection_time():
     # Simulate 10 s of a trigger, O2 and ECG
     T = 10
     nSamp = 100
-    fs = nSamp/T
+    fs = nSamp / T
     test_time = np.linspace(0, T, nSamp)
     test_freq = [fs, fs, fs, fs]
 
     # O2 as a sinusoidal of 0.5 Hz
-    test_O2 = np.sin(2*np.pi*0.5*test_time)
+    test_O2 = np.sin(2 * np.pi * 0.5 * test_time)
     # ECG as a sinusoidal with 1.5 Hz
-    test_ecg = np.sin(2*np.pi*1.5*test_time)
+    test_ecg = np.sin(2 * np.pi * 1.5 * test_time)
     # Trigger as a binary signal
     test_trigger = np.zeros(nSamp)
     test_trigger[1:nSamp:4] = 1
 
     test_timeseries = [test_time, test_O2, test_ecg, test_trigger]
-    test_chn_name = ['time', 'O2', 'ecg', 'tiger']
-    test_units = ['s', 'V', 'V', 'V']
+    test_chn_name = ["time", "O2", "ecg", "tiger"]
+    test_units = ["s", "V", "V", "V"]
 
     # test when chtrig is 0 and the trigger is not recognized by text matching:
     test_chtrig = 0
-    phys_in = po.BlueprintInput(test_timeseries, test_freq, test_chn_name,
-                                test_units, test_chtrig)
+    phys_in = po.BlueprintInput(test_timeseries, test_freq, test_chn_name, test_units, test_chtrig)
     assert phys_in.trigger_idx == 3

--- a/phys2bids/tests/test_utils.py
+++ b/phys2bids/tests/test_utils.py
@@ -5,6 +5,7 @@
 import json
 import os
 from csv import reader
+
 from pytest import raises
 
 from phys2bids import utils
@@ -12,13 +13,13 @@ from phys2bids import utils
 
 # Tests check_input_ext
 def test_check_input_ext():
-    test_filename = 'help'
-    ext = 'py'
+    test_filename = "help"
+    ext = "py"
     out_filename = utils.check_input_ext(test_filename, ext)
-    assert str(out_filename) == f'{test_filename}.{ext}'
+    assert str(out_filename) == f"{test_filename}.{ext}"
 
-    test_filename = 'help.txt.gz'
-    assert str(utils.check_input_ext(test_filename, ext)) == 'help.py'
+    test_filename = "help.txt.gz"
+    assert str(utils.check_input_ext(test_filename, ext)) == "help.py"
 
 
 # Tests check_input_type
@@ -26,7 +27,7 @@ def test_check_input_type(testpath, samefreq_full_acq_file):
     assert utils.check_input_type(samefreq_full_acq_file, testpath)
 
     with raises(Exception) as errorinfo:
-        utils.check_input_type('nobel_prize.win', testpath)
+        utils.check_input_type("nobel_prize.win", testpath)
     assert "was not found" in str(errorinfo.value)
 
 
@@ -35,58 +36,56 @@ def test_check_file_exists(samefreq_full_acq_file):
     utils.check_file_exists(samefreq_full_acq_file)
 
     with raises(Exception) as errorinfo:
-        utils.check_file_exists('')
-    assert 'does not exist' in str(errorinfo.value)
+        utils.check_file_exists("")
+    assert "does not exist" in str(errorinfo.value)
 
 
 # Tests copy_file
 def test_copy_file(tmpdir):
-    ext = '.txt'
-    test_old_path = tmpdir.join('foo.txt')
-    test_new_path = tmpdir.join('mrmeeseeks')
-    open(f'{test_old_path}.txt', 'a').close()
+    ext = ".txt"
+    test_old_path = tmpdir.join("foo.txt")
+    test_new_path = tmpdir.join("mrmeeseeks")
+    open(f"{test_old_path}.txt", "a").close()
     utils.copy_file(test_old_path, test_new_path, ext)
 
 
 # Tests write_file
 def test_write_file(tmpdir):
-    ext = '.txt'
-    test_old_path = tmpdir.join('foo.txt')
-    test_text = 'Wubba lubba dub dub!'
+    ext = ".txt"
+    test_old_path = tmpdir.join("foo.txt")
+    test_text = "Wubba lubba dub dub!"
     utils.write_file(test_old_path, ext, test_text)
 
 
 # Tests write_json
 def test_write_json(tmpdir):
-    test_json_filename = tmpdir.join('foo')
-    test_json_data = dict(SamplingFrequency=42,
-                          StartTime='00:00 ET',
-                          Columns='Rick')
+    test_json_filename = tmpdir.join("foo")
+    test_json_data = dict(SamplingFrequency=42, StartTime="00:00 ET", Columns="Rick")
     utils.write_json(str(test_json_filename), test_json_data, indent=4, sort_keys=False)
-    test_json_filename += '.json'
+    test_json_filename += ".json"
     assert os.path.isfile(test_json_filename)
-    with open(test_json_filename, 'r') as src:
+    with open(test_json_filename, "r") as src:
         loaded_data = json.load(src)
     assert test_json_data == loaded_data
 
 
 # Tests load_heuristics
 def test_load_heuristics():
-    test_heuristic = 'heur_test_acq'
+    test_heuristic = "heur_test_acq"
     heuristic_output_filename = utils.load_heuristic(test_heuristic).filename
     assert test_heuristic in heuristic_output_filename
 
     with raises(Exception) as errorinfo:
-        utils.load_heuristic('')
-    assert 'Failed to import heuristic' in str(errorinfo.value)
+        utils.load_heuristic("")
+    assert "Failed to import heuristic" in str(errorinfo.value)
 
 
 # Test writing rows util
 def test_append_list_as_row(tmpdir):
-    file_name = tmpdir.join('test_row.tsv')
-    list_of_elem = ["01", "32", 'some_info', "132.98", 'M']
+    file_name = tmpdir.join("test_row.tsv")
+    list_of_elem = ["01", "32", "some_info", "132.98", "M"]
     utils.append_list_as_row(file_name, list_of_elem)
-    with open(file_name, mode='r') as tsv:
+    with open(file_name, mode="r") as tsv:
         tsv_read = reader(tsv, delimiter="\t")
         for row in tsv_read:
             assert row == list_of_elem
@@ -99,30 +98,27 @@ def test_check_ge_bad_files(ge_badfiles):
     # Catch string
     with raises(Exception) as errorinfo:
         utils.check_ge(str_fname[1], str_fname[0])
-    assert 'not numerical' in str(errorinfo.value)
+    assert "not numerical" in str(errorinfo.value)
 
     # Catch multiple columns in csv file
     with raises(Exception) as errorinfo:
-        utils.check_ge('PPGData_epiRT_columnscsv_00_00_000',
-                       str_fname[0])
-    assert 'not numerical' in str(errorinfo.value)
+        utils.check_ge("PPGData_epiRT_columnscsv_00_00_000", str_fname[0])
+    assert "not numerical" in str(errorinfo.value)
 
     # Catch multiple columns in tsv file
     with raises(Exception) as errorinfo:
-        utils.check_ge('PPGData_epiRT_columnstsv_00_00_000',
-                       str_fname[0])
-    assert 'multiple columns' in str(errorinfo.value)
+        utils.check_ge("PPGData_epiRT_columnstsv_00_00_000", str_fname[0])
+    assert "multiple columns" in str(errorinfo.value)
 
 
 # Test that check_ge adds suffix to files appropriately
 def test_check_ge_add_suffix(ge_one_raw_file, ge_two_raw_files):
     # Single file
     in_fname = os.path.split(ge_one_raw_file)
-    utils.check_ge('PPGData_epiRT_0000000000_00_00_000', in_fname[0])
-    assert os.path.isfile(os.path.join(in_fname[0], in_fname[1]+'.gep'))
+    utils.check_ge("PPGData_epiRT_0000000000_00_00_000", in_fname[0])
+    assert os.path.isfile(os.path.join(in_fname[0], in_fname[1] + ".gep"))
 
     # Multiple files
     in_fname = os.path.split(ge_two_raw_files)
-    utils.check_ge('PPGData_epiRT_0000000000_00_00_000', in_fname[0])
-    assert os.path.isfile(os.path.join(in_fname[0],
-                                       'RESPData_epiRT_0000000000_00_00_000.gep'))
+    utils.check_ge("PPGData_epiRT_0000000000_00_00_000", in_fname[0])
+    assert os.path.isfile(os.path.join(in_fname[0], "RESPData_epiRT_0000000000_00_00_000.gep"))

--- a/phys2bids/tests/test_viz.py
+++ b/phys2bids/tests/test_viz.py
@@ -2,18 +2,24 @@ import os
 
 import pytest
 
-from phys2bids import io
-from phys2bids import viz
+from phys2bids import io, viz
 
 
 def test_plot_all(samefreq_full_acq_file):
     chtrig = 3
     test_path, test_filename = os.path.split(samefreq_full_acq_file)
     phys_obj = io.load_acq(samefreq_full_acq_file, chtrig)
-    viz.plot_all(phys_obj.ch_name, phys_obj.timeseries, phys_obj.units,
-                 phys_obj.freq, test_filename, outfile=test_path)
-    assert os.path.isfile(os.path.join(test_path,
-                          os.path.splitext(os.path.basename(test_filename))[0] + '.png'))
+    viz.plot_all(
+        phys_obj.ch_name,
+        phys_obj.timeseries,
+        phys_obj.units,
+        phys_obj.freq,
+        test_filename,
+        outfile=test_path,
+    )
+    assert os.path.isfile(
+        os.path.join(test_path, os.path.splitext(os.path.basename(test_filename))[0] + ".png")
+    )
 
 
 # Expected to fail due to trigger plot issue
@@ -21,8 +27,9 @@ def test_plot_all(samefreq_full_acq_file):
 def test_plot_trigger(samefreq_full_acq_file):
     chtrig = 3
     test_path, test_filename = os.path.split(samefreq_full_acq_file)
-    out = os.path.join(test_path, 'Test_belt_pulse_samefreq')
+    out = os.path.join(test_path, "Test_belt_pulse_samefreq")
     phys_obj = io.load_acq(samefreq_full_acq_file, chtrig)
-    viz.plot_trigger(phys_obj.timeseries[0], phys_obj.timeseries[chtrig],
-                     out, 1.5, 1.6, 60, test_filename)
-    assert os.path.isfile(out + '_trigger_time.png')
+    viz.plot_trigger(
+        phys_obj.timeseries[0], phys_obj.timeseries[chtrig], out, 1.5, 1.6, 60, test_filename
+    )
+    assert os.path.isfile(out + "_trigger_time.png")

--- a/phys2bids/utils.py
+++ b/phys2bids/utils.py
@@ -31,11 +31,11 @@ def check_input_ext(filename, ext):
     Path(filename).with_suffix(ext): path
         Path representing the input filename, but with corrected extension.
     """
-    if filename.endswith('.gz'):
+    if filename.endswith(".gz"):
         filename = filename[:-3]
 
-    if not ext.startswith('.'):
-        ext = '.' + ext
+    if not ext.startswith("."):
+        ext = "." + ext
 
     return Path(filename).with_suffix(ext)
 
@@ -78,8 +78,8 @@ def check_input_type(filename, indir):
             break
 
     if fftype_found:
-        LGR.info(f'File extension is .{ftype}')
-        LGR.warning('If both acq and txt files exist in the path, acq will be selected.')
+        LGR.info(f"File extension is .{ftype}")
+        LGR.warning("If both acq and txt files exist in the path, acq will be selected.")
         return fname, ftype
     else:
         raise Exception(f'The file {filename} was not found in {indir}'
@@ -104,7 +104,7 @@ def check_file_exists(filename):
         If the file doesn't exists.
     """
     if not os.path.isfile(filename) and filename is not None:
-        raise FileNotFoundError(f'The file {filename} does not exist!')
+        raise FileNotFoundError(f"The file {filename} does not exist!")
 
 
 def check_ge(filename, indir):
@@ -236,7 +236,7 @@ def write_file(filename, ext, text):
     filename + ext:
         Creates new file `filename.ext`.
     """
-    with open(filename + ext, 'w') as text_file:
+    with open(filename + ext, "w") as text_file:
         print(text, file=text_file)
 
 
@@ -258,9 +258,9 @@ def write_json(filename, data, **kwargs):
     filename:
         Creates new file `filename.json`.
     """
-    if not filename.endswith('.json'):
-        filename += '.json'
-    with open(filename, 'w') as out:
+    if not filename.endswith(".json"):
+        filename += ".json"
+    with open(filename, "w") as out:
         json.dump(data, out, **kwargs)
 
 
@@ -279,18 +279,19 @@ def load_heuristic(heuristic):
         try:
             old_syspath = sys.path[:]
             sys.path.append(path)
-            mod = __import__(fname.split('.')[0])
+            mod = __import__(fname.split(".")[0])
             mod.filename = heuristic_file
         finally:
             sys.path = old_syspath
     else:
         from importlib import import_module
+
         try:
-            mod = import_module(f'phys2bids.heuristics.{heuristic}')
+            mod = import_module(f"phys2bids.heuristics.{heuristic}")
             # remove c or o from pyc/pyo
-            mod.filename = mod.__file__.rstrip('co')
+            mod.filename = mod.__file__.rstrip("co")
         except Exception as exc:
-            raise ImportError(f'Failed to import heuristic {heuristic}: {exc}')
+            raise ImportError(f"Failed to import heuristic {heuristic}: {exc}")
     return mod
 
 
@@ -307,8 +308,8 @@ def append_list_as_row(file_name, list_of_elem):
         The list to be appended to the file.
     """
     # Open file in append mode
-    with open(file_name, 'a+', newline='') as write_obj:
+    with open(file_name, "a+", newline="") as write_obj:
         # Create a writer object from csv module
-        csv_writer = writer(write_obj, delimiter='\t')
+        csv_writer = writer(write_obj, delimiter="\t")
         # Add contents of list as last row in the csv file
         csv_writer.writerow(list_of_elem)

--- a/phys2bids/utils.py
+++ b/phys2bids/utils.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 LGR = logging.getLogger(__name__)
 
-SUPPORTED_FTYPES = ('acq', 'txt', 'mat', 'gep')
+SUPPORTED_FTYPES = ("acq", "txt", "mat", "gep")
 
 
 def check_input_ext(filename, ext):
@@ -82,10 +82,12 @@ def check_input_type(filename, indir):
         LGR.warning("If both acq and txt files exist in the path, acq will be selected.")
         return fname, ftype
     else:
-        raise Exception(f'The file {filename} was not found in {indir}'
-                        f' or {ftype} is not supported yet.\n'
-                        f'phys2bids currently supports:'
-                        f' {", ".join(SUPPORTED_FTYPES)}')
+        raise Exception(
+            f"The file {filename} was not found in {indir}"
+            f" or {ftype} is not supported yet.\n"
+            f"phys2bids currently supports:"
+            f' {", ".join(SUPPORTED_FTYPES)}'
+        )
 
 
 def check_file_exists(filename):
@@ -123,41 +125,41 @@ def check_ge(filename, indir):
         or a fullpath to such folder
 
     """
-    from numpy import loadtxt
     from glob import glob
 
-    ge_types = ['ECGData', 'PPGData', 'RESPData']
+    from numpy import loadtxt
+
+    ge_types = ["ECGData", "PPGData", "RESPData"]
 
     # Ensure the file exists
     if not os.path.isfile(os.path.join(indir, filename)) and filename is not None:
-        raise FileNotFoundError(f'The file {filename} does not exist!')
+        raise FileNotFoundError(f"The file {filename} does not exist!")
 
     # Check if it's a GE file and add file extension
     # Do the same for other linked files
     if any(ge_type in filename for ge_type in ge_types):
-        LGR.info('Filename with the form of GE physiological data entered')
+        LGR.info("Filename with the form of GE physiological data entered")
         #  Check that the file contents correspond to the format of GE files
         try:
             test_data = loadtxt(os.path.join(indir, filename))
             if len(test_data.shape) > 1:
-                LGR.info('File contents do not match GE format: multiple columns')
-                raise TypeError('File contents do not match GE format: multiple columns')
+                LGR.info("File contents do not match GE format: multiple columns")
+                raise TypeError("File contents do not match GE format: multiple columns")
         except ValueError:
-            LGR.info('File contents do not match GE format: not numerical')
-            raise TypeError('File contents do not match GE format: not numerical') from None
+            LGR.info("File contents do not match GE format: not numerical")
+            raise TypeError("File contents do not match GE format: not numerical") from None
         # Look for related GE files based on timestamp in name
-        fnames = glob(os.path.join(indir, f'*{filename[-20:]}*'))
+        fnames = glob(os.path.join(indir, f"*{filename[-20:]}*"))
         # Catch any tsv or json files
         for fname in fnames[:]:
-            if '.tsv.gz' in fname:
+            if ".tsv.gz" in fname:
                 fnames.remove(fname)
-            if '.json' in fname:
+            if ".json" in fname:
                 fnames.remove(fname)
         # Add extension to original so it's logged appropriately
-        if 'gep' not in filename[:-3]:
-            new_filename = filename + '.gep'
-            copy_file(os.path.join(indir, filename),
-                      os.path.join(indir, new_filename))
+        if "gep" not in filename[:-3]:
+            new_filename = filename + ".gep"
+            copy_file(os.path.join(indir, filename), os.path.join(indir, new_filename))
             LGR.info(f'Appending ".gep" extension to {filename}')
         else:
             LGR.info(f'".gep" extension already present in {filename}.')
@@ -165,25 +167,24 @@ def check_ge(filename, indir):
         # Remove the original filename from the list
         fnames.remove(os.path.join(indir, filename))
         try:
-            fnames.remove(os.path.join(indir, filename + '.gep'))
+            fnames.remove(os.path.join(indir, filename + ".gep"))
         except ValueError:
             pass
         # Log if there are no additional files
         if len(fnames) == 0:
-            LGR.info('No additional GE physiological files found')
+            LGR.info("No additional GE physiological files found")
         else:
-            LGR.info('Additional GE physiological file(s) found')
+            LGR.info("Additional GE physiological file(s) found")
             for fname in fnames[:]:
-                if 'gep' in fname[-3:]:
+                if "gep" in fname[-3:]:
                     LGR.info(f'".gep" extension already present in {fname.split("/")[-1]}.')
                 else:
-                    new_fname = fname + '.gep'
-                    copy_file(os.path.join(indir, fname),
-                              os.path.join(indir, new_fname))
+                    new_fname = fname + ".gep"
+                    copy_file(os.path.join(indir, fname), os.path.join(indir, new_fname))
                     LGR.info(f'Appending ".gep" extension to {fname.split("/")[-1]}.')
 
 
-def copy_file(oldpath, newpath, ext=''):
+def copy_file(oldpath, newpath, ext=""):
     """
     Copy file from oldpath to newpath.
 

--- a/phys2bids/viz.py
+++ b/phys2bids/viz.py
@@ -1,6 +1,6 @@
 """Visualization functions for phys2bids package."""
-import os
 import logging
+import os
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -11,8 +11,17 @@ SET_DPI = 100
 FIGSIZE = (18, 10)
 
 
-def plot_trigger(time, trigger, fileprefix, tr, thr, num_timepoints_expected,
-                 filename, figsize=FIGSIZE, dpi=SET_DPI):
+def plot_trigger(
+    time,
+    trigger,
+    fileprefix,
+    tr,
+    thr,
+    num_timepoints_expected,
+    filename,
+    figsize=FIGSIZE,
+    dpi=SET_DPI,
+):
     """
     Produce a figure with three plots.
 
@@ -63,6 +72,7 @@ def plot_trigger(time, trigger, fileprefix, tr, thr, num_timepoints_expected,
 
     def ntr2time(x):
         return x * tr
+
     # get filename
     outname = os.path.splitext(os.path.basename(filename))[0]
     # create threshold line
@@ -74,64 +84,74 @@ def plot_trigger(time, trigger, fileprefix, tr, thr, num_timepoints_expected,
     plt.subplots_adjust(hspace=0.7)
     # plot of the hole trigger
     subplot = fig.add_subplot(211)
-    subplot.set_title(f'Trigger and time for {outname}.tsv.gz')
+    subplot.set_title(f"Trigger and time for {outname}.tsv.gz")
     subplot.set_ylim([-0.2, thr * 3])
-    subplot.set_xlabel('Seconds')
-    subplot.set_ylabel('Volts')
-    subplot.plot(time, trigger, '-', time, thrline, 'r-.', time, block, '-')
-    subplot.fill_between(time, block, where=block >= d, interpolate=True, color='#ffbb6e')
-    subplot.legend(['trigger', 'Trigger detection threshold', 'time block'], loc='upper right')
+    subplot.set_xlabel("Seconds")
+    subplot.set_ylabel("Volts")
+    subplot.plot(time, trigger, "-", time, thrline, "r-.", time, block, "-")
+    subplot.fill_between(time, block, where=block >= d, interpolate=True, color="#ffbb6e")
+    subplot.legend(["trigger", "Trigger detection threshold", "time block"], loc="upper right")
     # plot the first spike according to the user threshold
     subplot = fig.add_subplot(223)
     subplot.set_xlim([-tr * 4, tr * 4])
     subplot.set_ylim([-0.2, thr * 3])
-    subplot.set_xlabel('Seconds')
-    subplot.set_ylabel('Volts')
+    subplot.set_xlabel("Seconds")
+    subplot.set_ylabel("Volts")
     ax2 = subplot.twiny()
-    ax2.set_xticklabels('')
+    ax2.set_xticklabels("")
     ax2.tick_params(
-                    axis='x',          # changes apply to the x-axis
-                    which='both',      # both major and minor ticks are affected
-                    bottom=False,      # ticks along the bottom edge are off
-                    top=False,         # ticks along the top edge are off
-                    labelbottom=False,
-                    pad=15)
+        axis="x",  # changes apply to the x-axis
+        which="both",  # both major and minor ticks are affected
+        bottom=False,  # ticks along the bottom edge are off
+        top=False,  # ticks along the top edge are off
+        labelbottom=False,
+        pad=15,
+    )
     # add secondary axis ticks
-    subplot.secondary_xaxis('top', functions=(time2ntr, ntr2time))
+    subplot.secondary_xaxis("top", functions=(time2ntr, ntr2time))
     # add secondary axis labelS
-    ax2.set_xlabel('TR')
-    subplot.plot(time, trigger, '-', time, block, '-')
-    subplot.fill_between(time, block, where=block >= d, interpolate=True, color='#ffbb6e')
-    ax2.set_title('Starting triggers for selected threshold')
+    ax2.set_xlabel("TR")
+    subplot.plot(time, trigger, "-", time, block, "-")
+    subplot.fill_between(time, block, where=block >= d, interpolate=True, color="#ffbb6e")
+    ax2.set_title("Starting triggers for selected threshold")
     # plot the last spike according to the user threshold
     subplot = fig.add_subplot(224)
-    subplot.set_xlim([tr * (num_timepoints_expected) - 4,
-                      tr * (num_timepoints_expected) + 4])
-    subplot.set_xlabel('Seconds')
-    subplot.set_ylabel('Volts')
+    subplot.set_xlim([tr * (num_timepoints_expected) - 4, tr * (num_timepoints_expected) + 4])
+    subplot.set_xlabel("Seconds")
+    subplot.set_ylabel("Volts")
     subplot.set_ylim([-0.2, thr * 3])
     ax2 = subplot.twiny()
-    ax2.set_xticklabels('')
+    ax2.set_xticklabels("")
     ax2.tick_params(
-                    axis='x',          # changes apply to the x-axis
-                    which='both',      # both major and minor ticks are affected
-                    bottom=False,      # ticks along the bottom edge are off
-                    top=False,         # ticks along the top edge are off
-                    labelbottom=False,
-                    pad=15)
-    subplot.secondary_xaxis('top', functions=(time2ntr, ntr2time))
-    ax2.set_xlabel('TR')
-    ax2.set_title('Ending triggers for selected threshold')
-    subplot.plot(time, trigger, '-', time, block, '-')
-    subplot.fill_between(time, block, where=block >= d, interpolate=True, color='#ffbb6e')
-    if 'PYTEST_CURRENT_TEST' not in os.environ:
-        plt.savefig(fileprefix + '_trigger_time.png', dpi=dpi)
+        axis="x",  # changes apply to the x-axis
+        which="both",  # both major and minor ticks are affected
+        bottom=False,  # ticks along the bottom edge are off
+        top=False,  # ticks along the top edge are off
+        labelbottom=False,
+        pad=15,
+    )
+    subplot.secondary_xaxis("top", functions=(time2ntr, ntr2time))
+    ax2.set_xlabel("TR")
+    ax2.set_title("Ending triggers for selected threshold")
+    subplot.plot(time, trigger, "-", time, block, "-")
+    subplot.fill_between(time, block, where=block >= d, interpolate=True, color="#ffbb6e")
+    if "PYTEST_CURRENT_TEST" not in os.environ:
+        plt.savefig(fileprefix + "_trigger_time.png", dpi=dpi)
     plt.close()
 
 
-def export_trigger_plot(phys_in, chtrig, fileprefix, tr, num_timepoints_expected,
-                        filename, sub=None, ses=None, figsize=FIGSIZE,
-                        dpi=SET_DPI):
+def export_trigger_plot(
+    phys_in,
+    chtrig,
+    fileprefix,
+    tr,
+    num_timepoints_expected,
+    filename,
+    sub=None,
+    ses=None,
+    figsize=FIGSIZE,
+    dpi=SET_DPI,
+):
     """
     Save a trigger plot.
 
@@ -166,13 +186,13 @@ def export_trigger_plot(phys_in, chtrig, fileprefix, tr, num_timepoints_expected
         Desired DPI of the figure,
         Default is {SET_DPI}
     """
-    LGR.info('Plot trigger')
+    LGR.info("Plot trigger")
     # Create trigger plot. If possible, to have multiple outputs in the same
     # place, adds sub and ses label.
     if sub is not None:
-        fileprefix += f'_sub-{sub}'
+        fileprefix += f"_sub-{sub}"
     if ses is not None:
-        fileprefix += f'_ses-{ses}'
+        fileprefix += f"_ses-{ses}"
 
     if phys_in._time_resampled_to_trigger is None:
         timeseries_plot = phys_in.timeseries[0]
@@ -180,9 +200,17 @@ def export_trigger_plot(phys_in, chtrig, fileprefix, tr, num_timepoints_expected
         timeseries_plot = phys_in._time_resampled_to_trigger
 
     # adjust for multi run arguments, iterate through acquisition attributes
-    plot_trigger(timeseries_plot, phys_in.timeseries[chtrig],
-                 fileprefix, tr, phys_in.thr, num_timepoints_expected,
-                 filename, figsize, dpi)
+    plot_trigger(
+        timeseries_plot,
+        phys_in.timeseries[chtrig],
+        fileprefix,
+        tr,
+        phys_in.thr,
+        num_timepoints_expected,
+        filename,
+        figsize,
+        dpi,
+    )
 
 
 def plot_all(ch_name, timeseries, units, freq, infile, outfile, dpi=SET_DPI, size=FIGSIZE):
@@ -231,11 +259,11 @@ def plot_all(ch_name, timeseries, units, freq, infile, outfile, dpi=SET_DPI, siz
             time_old = np.linspace(0, time[-1], num=timeser.shape[0])
             timeser = np.interp(time, time_old, timeser)
         ax[row].plot(time, timeser)
-        ax[row].set_title(f' Channel {row + 1}: {ch_name[row + 1]}')
+        ax[row].set_title(f" Channel {row + 1}: {ch_name[row + 1]}")
         ax[row].set_ylabel(units[row + 1])
         ax[row].xlim = 30 * 60 * freq[0]  # maximum display of half an hour
         ax[row].grid()
-    ax[row].set_xlabel('seconds')
-    outfile = os.path.join(outfile, os.path.splitext(os.path.basename(infile))[0] + '.png')
-    LGR.info(f'saving channel plot to {outfile}')
-    fig.savefig(outfile, dpi=dpi, bbox_inches='tight')
+    ax[row].set_xlabel("seconds")
+    outfile = os.path.join(outfile, os.path.splitext(os.path.basename(infile))[0] + ".png")
+    LGR.info(f"saving channel plot to {outfile}")
+    fig.savefig(outfile, dpi=dpi, bbox_inches="tight")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.black]
+line-length = 99
+target-version = ['py37']
+include = '\.pyi?$'
+exclude = '''
+(
+  /(
+      \.eggs         # exclude a few common directories in the
+    | \.git          # root of the project
+    | \.github
+    | \.hg
+    | \.pytest_cache
+    | _build
+    | build
+    | dist
+  )/
+  | versioneer.py
+  | phys2bids/_version.py
+)
+'''

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,9 +48,6 @@ doc =
     sphinx_rtd_theme
 style =
     flake8 >=4.0
-    flake8-black >=0.2.1
-    flake8-docstrings >=1.5
-    flake8-isort
     black
     isort <6.0.0
     pydocstyle

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ doc =
 style =
     flake8-black >=0.2.1
     flake8-docstrings >=1.5
+    flake8-isort
     codespell
 interfaces =
     %(acq)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -85,7 +85,7 @@ exclude=
     ./phys2bids/cli/__init__.py
     ./phys2bids/tests/*
     versioneer.py
-ignore = E126, E402, W503, E226
+ignore = E126, E402, W503, E226, E203
 max-line-length = 99
 per-file-ignores =
     */__init__.py:F401

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ doc =
     sphinx-argparse
     sphinx_rtd_theme
 style =
-    flake8 >=3.7
+    flake8-black >=0.2.1
     flake8-docstrings >=1.5
     codespell
 interfaces =

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,9 +47,13 @@ doc =
     sphinx-argparse
     sphinx_rtd_theme
 style =
+    flake8 >=4.0
     flake8-black >=0.2.1
     flake8-docstrings >=1.5
     flake8-isort
+    black
+    isort <6.0.0
+    pydocstyle
     codespell
 interfaces =
     %(acq)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,8 @@ console_scripts =
     phys2bids=phys2bids.phys2bids:_main
 
 [flake8]
-exclude=
+doctest = True
+exclude =
     *build/
     heuristics
     tests
@@ -86,10 +87,27 @@ exclude=
     ./phys2bids/cli/__init__.py
     ./phys2bids/tests/*
     versioneer.py
-ignore = E126, E402, W503, E226, E203
-max-line-length = 99
+ignore = E126, E402, W503, E226, F401, F811
+max-line-length = 88
+extend-ignore = E203, E501
+extend-select = B950
 per-file-ignores =
-    */__init__.py:F401
+    workflow.py:D401
+
+[isort]
+profile = black
+skip_gitignore = true
+extend_skip =
+    .autorc
+    .coverage*
+    .readthedocs.yml
+    .zenodo.json
+    codecov.yml
+    setup.py
+    versioneer.py
+    phys2bids/_version.py
+skip_glob =
+    docs/*
 
 [pydocstyle]
 convention = numpy

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,13 @@ import sys
 from setuptools import setup
 import versioneer
 
-SETUP_REQUIRES = ['setuptools >= 30.3.0']
-SETUP_REQUIRES += ['wheel'] if 'bdist_wheel' in sys.argv else []
+SETUP_REQUIRES = ["setuptools >= 30.3.0"]
+SETUP_REQUIRES += ["wheel"] if "bdist_wheel" in sys.argv else []
 
 if __name__ == "__main__":
-    setup(name='phys2bids',
-          setup_requires=SETUP_REQUIRES,
-          version=versioneer.get_version(),
-          cmdclass=versioneer.get_cmdclass())
+    setup(
+        name="phys2bids",
+        setup_requires=SETUP_REQUIRES,
+        version=versioneer.get_version(),
+        cmdclass=versioneer.get_cmdclass(),
+    )

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,4 +1,3 @@
-
 # Version: 0.18
 
 """The Versioneer - like a rocketeer, but for versions.
@@ -277,6 +276,7 @@ https://creativecommons.org/publicdomain/zero/1.0/ .
 """
 
 from __future__ import print_function
+
 try:
     import configparser
 except ImportError:
@@ -308,11 +308,13 @@ def get_root():
         setup_py = os.path.join(root, "setup.py")
         versioneer_py = os.path.join(root, "versioneer.py")
     if not (os.path.exists(setup_py) or os.path.exists(versioneer_py)):
-        err = ("Versioneer was unable to run the project root directory. "
-               "Versioneer requires setup.py to be executed from "
-               "its immediate directory (like 'python setup.py COMMAND'), "
-               "or in a way that lets it use sys.argv[0] to find the root "
-               "(like 'python path/to/setup.py COMMAND').")
+        err = (
+            "Versioneer was unable to run the project root directory. "
+            "Versioneer requires setup.py to be executed from "
+            "its immediate directory (like 'python setup.py COMMAND'), "
+            "or in a way that lets it use sys.argv[0] to find the root "
+            "(like 'python path/to/setup.py COMMAND')."
+        )
         raise VersioneerBadRootError(err)
     try:
         # Certain runtime workflows (setup.py install/develop in a setuptools
@@ -325,8 +327,10 @@ def get_root():
         me_dir = os.path.normcase(os.path.splitext(me)[0])
         vsr_dir = os.path.normcase(os.path.splitext(versioneer_py)[0])
         if me_dir != vsr_dir:
-            print("Warning: build in %s is using versioneer.py from %s"
-                  % (os.path.dirname(me), versioneer_py))
+            print(
+                "Warning: build in %s is using versioneer.py from %s"
+                % (os.path.dirname(me), versioneer_py)
+            )
     except NameError:
         pass
     return root
@@ -348,6 +352,7 @@ def get_config_from_root(root):
         if parser.has_option("versioneer", name):
             return parser.get("versioneer", name)
         return None
+
     cfg = VersioneerConfig()
     cfg.VCS = VCS
     cfg.style = get(parser, "style") or ""
@@ -372,17 +377,18 @@ HANDLERS = {}
 
 def register_vcs_handler(vcs, method):  # decorator
     """Decorator to mark a method as the handler for a particular VCS."""
+
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:
             HANDLERS[vcs] = {}
         HANDLERS[vcs][method] = f
         return f
+
     return decorate
 
 
-def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
-                env=None):
+def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=None):
     """Call the given command(s)."""
     assert isinstance(commands, list)
     p = None
@@ -390,10 +396,13 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
         try:
             dispcmd = str([c] + args)
             # remember shell=False, so use git.cmd on windows, not just git
-            p = subprocess.Popen([c] + args, cwd=cwd, env=env,
-                                 stdout=subprocess.PIPE,
-                                 stderr=(subprocess.PIPE if hide_stderr
-                                         else None))
+            p = subprocess.Popen(
+                [c] + args,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=(subprocess.PIPE if hide_stderr else None),
+            )
             break
         except EnvironmentError:
             e = sys.exc_info()[1]
@@ -418,7 +427,9 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
     return stdout, p.returncode
 
 
-LONG_VERSION_PY['git'] = '''
+LONG_VERSION_PY[
+    "git"
+] = '''
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -993,7 +1004,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    tags = set([r[len(TAG) :] for r in refs if r.startswith(TAG)])
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -1002,7 +1013,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r'\d', r)])
+        tags = set([r for r in refs if re.search(r"\d", r)])
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -1010,19 +1021,26 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
-            r = ref[len(tag_prefix):]
+            r = ref[len(tag_prefix) :]
             if verbose:
                 print("picking %s" % r)
-            return {"version": r,
-                    "full-revisionid": keywords["full"].strip(),
-                    "dirty": False, "error": None,
-                    "date": date}
+            return {
+                "version": r,
+                "full-revisionid": keywords["full"].strip(),
+                "dirty": False,
+                "error": None,
+                "date": date,
+            }
     # no suitable tags, so version is "0+unknown", but full hex is still there
     if verbose:
         print("no suitable tags, using unknown + full revision id")
-    return {"version": "0+unknown",
-            "full-revisionid": keywords["full"].strip(),
-            "dirty": False, "error": "no suitable tags", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": keywords["full"].strip(),
+        "dirty": False,
+        "error": "no suitable tags",
+        "date": None,
+    }
 
 
 @register_vcs_handler("git", "pieces_from_vcs")
@@ -1037,8 +1055,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
 
-    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root,
-                          hide_stderr=True)
+    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root, hide_stderr=True)
     if rc != 0:
         if verbose:
             print("Directory %s not under git control" % root)
@@ -1046,10 +1063,11 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
-                                          "--always", "--long",
-                                          "--match", "%s*" % tag_prefix],
-                                   cwd=root)
+    describe_out, rc = run_command(
+        GITS,
+        ["describe", "--tags", "--dirty", "--always", "--long", "--match", "%s*" % tag_prefix],
+        cwd=root,
+    )
     # --long was added in git-1.5.5
     if describe_out is None:
         raise NotThisMethod("'git describe' failed")
@@ -1072,17 +1090,16 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     dirty = git_describe.endswith("-dirty")
     pieces["dirty"] = dirty
     if dirty:
-        git_describe = git_describe[:git_describe.rindex("-dirty")]
+        git_describe = git_describe[: git_describe.rindex("-dirty")]
 
     # now we have TAG-NUM-gHEX or HEX
 
     if "-" in git_describe:
         # TAG-NUM-gHEX
-        mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
+        mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
         if not mo:
             # unparseable. Maybe git-describe is misbehaving?
-            pieces["error"] = ("unable to parse git-describe output: '%s'"
-                               % describe_out)
+            pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
             return pieces
 
         # tag
@@ -1091,10 +1108,9 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
-                               % (full_tag, tag_prefix))
+            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (full_tag, tag_prefix)
             return pieces
-        pieces["closest-tag"] = full_tag[len(tag_prefix):]
+        pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
         # distance: number of commits since tag
         pieces["distance"] = int(mo.group(2))
@@ -1105,13 +1121,11 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     else:
         # HEX: no tags
         pieces["closest-tag"] = None
-        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
-                                    cwd=root)
+        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"], cwd=root)
         pieces["distance"] = int(count_out)  # total number of commits
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()
-    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"],
-                       cwd=root)[0].strip()
+    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"], cwd=root)[0].strip()
     pieces["date"] = date.strip().replace(" ", "T", 1).replace(" ", "", 1)
 
     return pieces
@@ -1167,16 +1181,22 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     for i in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
-            return {"version": dirname[len(parentdir_prefix):],
-                    "full-revisionid": None,
-                    "dirty": False, "error": None, "date": None}
+            return {
+                "version": dirname[len(parentdir_prefix) :],
+                "full-revisionid": None,
+                "dirty": False,
+                "error": None,
+                "date": None,
+            }
         else:
             rootdirs.append(root)
             root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print("Tried directories %s but none started with prefix %s" %
-              (str(rootdirs), parentdir_prefix))
+        print(
+            "Tried directories %s but none started with prefix %s"
+            % (str(rootdirs), parentdir_prefix)
+        )
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 
@@ -1205,11 +1225,9 @@ def versions_from_file(filename):
             contents = f.read()
     except EnvironmentError:
         raise NotThisMethod("unable to read _version.py")
-    mo = re.search(r"version_json = '''\n(.*)'''  # END VERSION_JSON",
-                   contents, re.M | re.S)
+    mo = re.search(r"version_json = '''\n(.*)'''  # END VERSION_JSON", contents, re.M | re.S)
     if not mo:
-        mo = re.search(r"version_json = '''\r\n(.*)'''  # END VERSION_JSON",
-                       contents, re.M | re.S)
+        mo = re.search(r"version_json = '''\r\n(.*)'''  # END VERSION_JSON", contents, re.M | re.S)
     if not mo:
         raise NotThisMethod("no version_json in _version.py")
     return json.loads(mo.group(1))
@@ -1218,8 +1236,7 @@ def versions_from_file(filename):
 def write_to_version_file(filename, versions):
     """Write the given version number to the given _version.py file."""
     os.unlink(filename)
-    contents = json.dumps(versions, sort_keys=True,
-                          indent=1, separators=(",", ": "))
+    contents = json.dumps(versions, sort_keys=True, indent=1, separators=(",", ": "))
     with open(filename, "w") as f:
         f.write(SHORT_VERSION_PY % contents)
 
@@ -1251,8 +1268,7 @@ def render_pep440(pieces):
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -1366,11 +1382,13 @@ def render_git_describe_long(pieces):
 def render(pieces, style):
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
-        return {"version": "unknown",
-                "full-revisionid": pieces.get("long"),
-                "dirty": None,
-                "error": pieces["error"],
-                "date": None}
+        return {
+            "version": "unknown",
+            "full-revisionid": pieces.get("long"),
+            "dirty": None,
+            "error": pieces["error"],
+            "date": None,
+        }
 
     if not style or style == "default":
         style = "pep440"  # the default
@@ -1390,9 +1408,13 @@ def render(pieces, style):
     else:
         raise ValueError("unknown style '%s'" % style)
 
-    return {"version": rendered, "full-revisionid": pieces["long"],
-            "dirty": pieces["dirty"], "error": None,
-            "date": pieces.get("date")}
+    return {
+        "version": rendered,
+        "full-revisionid": pieces["long"],
+        "dirty": pieces["dirty"],
+        "error": None,
+        "date": pieces.get("date"),
+    }
 
 
 class VersioneerBadRootError(Exception):
@@ -1415,8 +1437,7 @@ def get_versions(verbose=False):
     handlers = HANDLERS.get(cfg.VCS)
     assert handlers, "unrecognized VCS '%s'" % cfg.VCS
     verbose = verbose or cfg.verbose
-    assert cfg.versionfile_source is not None, \
-        "please set versioneer.versionfile_source"
+    assert cfg.versionfile_source is not None, "please set versioneer.versionfile_source"
     assert cfg.tag_prefix is not None, "please set versioneer.tag_prefix"
 
     versionfile_abs = os.path.join(root, cfg.versionfile_source)
@@ -1470,9 +1491,13 @@ def get_versions(verbose=False):
     if verbose:
         print("unable to compute version")
 
-    return {"version": "0+unknown", "full-revisionid": None,
-            "dirty": None, "error": "unable to compute version",
-            "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": None,
+        "dirty": None,
+        "error": "unable to compute version",
+        "date": None,
+    }
 
 
 def get_version():
@@ -1521,6 +1546,7 @@ def get_cmdclass():
             print(" date: %s" % vers.get("date"))
             if vers["error"]:
                 print(" error: %s" % vers["error"])
+
     cmds["version"] = cmd_version
 
     # we override "build_py" in both distutils and setuptools
@@ -1553,14 +1579,15 @@ def get_cmdclass():
             # now locate _version.py in the new build/ directory and replace
             # it with an updated value
             if cfg.versionfile_build:
-                target_versionfile = os.path.join(self.build_lib,
-                                                  cfg.versionfile_build)
+                target_versionfile = os.path.join(self.build_lib, cfg.versionfile_build)
                 print("UPDATING %s" % target_versionfile)
                 write_to_version_file(target_versionfile, versions)
+
     cmds["build_py"] = cmd_build_py
 
     if "cx_Freeze" in sys.modules:  # cx_freeze enabled?
         from cx_Freeze.dist import build_exe as _build_exe
+
         # nczeczulin reports that py2exe won't like the pep440-style string
         # as FILEVERSION, but it can be used for PRODUCTVERSION, e.g.
         # setup(console=[{
@@ -1581,17 +1608,21 @@ def get_cmdclass():
                 os.unlink(target_versionfile)
                 with open(cfg.versionfile_source, "w") as f:
                     LONG = LONG_VERSION_PY[cfg.VCS]
-                    f.write(LONG %
-                            {"DOLLAR": "$",
-                             "STYLE": cfg.style,
-                             "TAG_PREFIX": cfg.tag_prefix,
-                             "PARENTDIR_PREFIX": cfg.parentdir_prefix,
-                             "VERSIONFILE_SOURCE": cfg.versionfile_source,
-                             })
+                    f.write(
+                        LONG
+                        % {
+                            "DOLLAR": "$",
+                            "STYLE": cfg.style,
+                            "TAG_PREFIX": cfg.tag_prefix,
+                            "PARENTDIR_PREFIX": cfg.parentdir_prefix,
+                            "VERSIONFILE_SOURCE": cfg.versionfile_source,
+                        }
+                    )
+
         cmds["build_exe"] = cmd_build_exe
         del cmds["build_py"]
 
-    if 'py2exe' in sys.modules:  # py2exe enabled?
+    if "py2exe" in sys.modules:  # py2exe enabled?
         try:
             from py2exe.distutils_buildexe import py2exe as _py2exe  # py3
         except ImportError:
@@ -1610,13 +1641,17 @@ def get_cmdclass():
                 os.unlink(target_versionfile)
                 with open(cfg.versionfile_source, "w") as f:
                     LONG = LONG_VERSION_PY[cfg.VCS]
-                    f.write(LONG %
-                            {"DOLLAR": "$",
-                             "STYLE": cfg.style,
-                             "TAG_PREFIX": cfg.tag_prefix,
-                             "PARENTDIR_PREFIX": cfg.parentdir_prefix,
-                             "VERSIONFILE_SOURCE": cfg.versionfile_source,
-                             })
+                    f.write(
+                        LONG
+                        % {
+                            "DOLLAR": "$",
+                            "STYLE": cfg.style,
+                            "TAG_PREFIX": cfg.tag_prefix,
+                            "PARENTDIR_PREFIX": cfg.parentdir_prefix,
+                            "VERSIONFILE_SOURCE": cfg.versionfile_source,
+                        }
+                    )
+
         cmds["py2exe"] = cmd_py2exe
 
     # we override different "sdist" commands for both environments
@@ -1643,8 +1678,8 @@ def get_cmdclass():
             # updated value
             target_versionfile = os.path.join(base_dir, cfg.versionfile_source)
             print("UPDATING %s" % target_versionfile)
-            write_to_version_file(target_versionfile,
-                                  self._versioneer_generated_versions)
+            write_to_version_file(target_versionfile, self._versioneer_generated_versions)
+
     cmds["sdist"] = cmd_sdist
 
     return cmds
@@ -1699,11 +1734,9 @@ def do_setup():
     root = get_root()
     try:
         cfg = get_config_from_root(root)
-    except (EnvironmentError, configparser.NoSectionError,
-            configparser.NoOptionError) as e:
+    except (EnvironmentError, configparser.NoSectionError, configparser.NoOptionError) as e:
         if isinstance(e, (EnvironmentError, configparser.NoSectionError)):
-            print("Adding sample versioneer config to setup.cfg",
-                  file=sys.stderr)
+            print("Adding sample versioneer config to setup.cfg", file=sys.stderr)
             with open(os.path.join(root, "setup.cfg"), "a") as f:
                 f.write(SAMPLE_CONFIG)
         print(CONFIG_ERROR, file=sys.stderr)
@@ -1712,15 +1745,18 @@ def do_setup():
     print(" creating %s" % cfg.versionfile_source)
     with open(cfg.versionfile_source, "w") as f:
         LONG = LONG_VERSION_PY[cfg.VCS]
-        f.write(LONG % {"DOLLAR": "$",
-                        "STYLE": cfg.style,
-                        "TAG_PREFIX": cfg.tag_prefix,
-                        "PARENTDIR_PREFIX": cfg.parentdir_prefix,
-                        "VERSIONFILE_SOURCE": cfg.versionfile_source,
-                        })
+        f.write(
+            LONG
+            % {
+                "DOLLAR": "$",
+                "STYLE": cfg.style,
+                "TAG_PREFIX": cfg.tag_prefix,
+                "PARENTDIR_PREFIX": cfg.parentdir_prefix,
+                "VERSIONFILE_SOURCE": cfg.versionfile_source,
+            }
+        )
 
-    ipy = os.path.join(os.path.dirname(cfg.versionfile_source),
-                       "__init__.py")
+    ipy = os.path.join(os.path.dirname(cfg.versionfile_source), "__init__.py")
     if os.path.exists(ipy):
         try:
             with open(ipy, "r") as f:
@@ -1762,8 +1798,7 @@ def do_setup():
     else:
         print(" 'versioneer.py' already in MANIFEST.in")
     if cfg.versionfile_source not in simple_includes:
-        print(" appending versionfile_source ('%s') to MANIFEST.in" %
-              cfg.versionfile_source)
+        print(" appending versionfile_source ('%s') to MANIFEST.in" % cfg.versionfile_source)
         with open(manifest_in, "a") as f:
             f.write("include %s\n" % cfg.versionfile_source)
     else:


### PR DESCRIPTION
Closes #324. 

## Proposed Changes

  - Change `flake8` dependency to `flake8-black`. Calling `flake8` in the CI will use `flake8-black` automatically.
  - Ignore E203 (whitespace before ':'), which `flake8` flags, but which is actually not PEP8 compliant. See [here](https://black.readthedocs.io/en/stable/compatible_configs.html#flake8) for an explanation.