### PR TITLE
Update PyYAML minimal requirements to avoid "FullLoader" attribute errors.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,8 +9,9 @@ Requirements
 
 ``phys2bids`` requires python 3.6 or above, as well as the modules:
 
-- ``numpy >= 1.9.3``
-- ``matplotlib >= 3.1.1``
+.. literalinclude:: ../setup.cfg
+   :lines: 25-27
+   :dedent: 4
 
 Depending on the processed files, it might require the **manual installation** of extra modules.
 At the moment, those modules are:

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ python_requires = >=3.6.1
 install_requires =
     numpy >=1.9.3, !=*rc*
     matplotlib >=3.1.1, !=3.3.0rc1
-    PyYAML >=5.1 !=*rc*
+    PyYAML >=5.1, !=*rc*
 tests_require =
     pytest >=5.3
 test_suite = pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ python_requires = >=3.6.1
 install_requires =
     numpy >=1.9.3, !=*rc*
     matplotlib >=3.1.1, !=3.3.0rc1
-    PyYAML !=*rc*
+    PyYAML >=5.1 !=*rc*
 tests_require =
     pytest >=5.3
 test_suite = pytest


### PR DESCRIPTION
Closes none

While running a test locally, I realised that we need to force the version of PyYAML to be 5.1 or above for our scripts to work: https://stackoverflow.com/questions/55551191/module-yaml-has-no-attribute-fullloader

## Proposed Changes

  - Update PyYAML requirements
  - Update requirements in documentation