### PR TITLE
Fix typo in artifact_path

### DIFF
--- a/.circleci/artifact_path
+++ b/.circleci/artifact_path
@@ -1,1 +1,1 @@
-0/tmp/src/phy2sbids/docs/_build/html/index.html
+0/tmp/src/phys2bids/docs/_build/html/index.html


### PR DESCRIPTION
References #300, but probably doesn't fix it.

## Proposed Changes

  - Fix a typo in the artifact path used to build the path for the `build_docs_artifact` CI step. This should fix the link for PRs from forks _without_ CircleCI running.