### PR TITLE
Remove utils.move_file function as it is no longer used in the toolbox

### DIFF
--- a/phys2bids/tests/test_utils.py
+++ b/phys2bids/tests/test_utils.py
@@ -58,17 +58,6 @@ def test_check_file_exists(samefreq_full_acq_file):
     assert 'does not exist' in str(errorinfo.value)
 
 
-# Tests move_file
-def test_move_file(tmpdir):
-    ext = '.txt'
-    test_old_path = tmpdir.join('foo.txt')
-    with open(test_old_path, 'a'):
-        pass
-    test_old_path = str(test_old_path)[:-4]
-    test_new_path = tmpdir.join('mrmeeseeks')
-    utils.move_file(test_old_path, test_new_path, ext)
-
-
 # Tests copy_file
 def test_copy_file(tmpdir):
     ext = '.txt'

--- a/phys2bids/utils.py
+++ b/phys2bids/utils.py
@@ -148,36 +148,6 @@ def check_file_exists(filename):
     if not os.path.isfile(filename) and filename is not None:
         raise FileNotFoundError(f'The file {filename} does not exist!')
 
-
-def move_file(oldpath, newpath, ext=''):
-    """
-    Move file from oldpath to newpath.
-
-    If file already exists, removes it first.
-
-    Parameters
-    ----------
-    oldpath: str or path
-        A string or a fullpath to a file that has to be moved
-    newpath: str or path
-        A string or a fullpath to the new destination of the file
-    ext: str
-        Possible extension to add to the oldpath and newpath. Not necessary.
-
-    Notes
-    -----
-    Outcome:
-    newpath + ext:
-        Moves file to new destination
-    """
-    check_file_exists(oldpath + ext)
-
-    if os.path.isfile(newpath + ext):
-        os.remove(newpath + ext)
-
-    os.rename(oldpath + ext, newpath + ext)
-
-
 def copy_file(oldpath, newpath, ext=''):
     """
     Copy file from oldpath to newpath.

--- a/phys2bids/utils.py
+++ b/phys2bids/utils.py
@@ -147,6 +147,7 @@ def check_file_exists(filename):
     """
     if not os.path.isfile(filename) and filename is not None:
         raise FileNotFoundError(f'The file {filename} does not exist!')
+        
 
 def copy_file(oldpath, newpath, ext=''):
     """

--- a/phys2bids/utils.py
+++ b/phys2bids/utils.py
@@ -147,7 +147,7 @@ def check_file_exists(filename):
     """
     if not os.path.isfile(filename) and filename is not None:
         raise FileNotFoundError(f'The file {filename} does not exist!')
-        
+
 
 def copy_file(oldpath, newpath, ext=''):
     """


### PR DESCRIPTION
#Closes #336 and #closes #337 

## Proposed Changes

  - Removes the in-house built function to move the files from the Utilities collection;
  - Removes the test for in-house built function to move the files from the Unit test for Utilities collection.