### PR TITLE
Rename function `utils.writefile` to `utils.write_file` to respect style

### DIFF
--- a/phys2bids/bids.py
+++ b/phys2bids/bids.py
@@ -289,4 +289,4 @@ def readme_file(outdir):
         text = 'Empty README, please fill in describing the dataset in more detail.'
         LGR.warning('phys2bids could not find README,'
                     'generating it EMPTY, please fill in the necessary info')
-        utils.writefile(file_path, '', text)
+        utils.write_file(file_path, '', text)

--- a/phys2bids/phys2bids.py
+++ b/phys2bids/phys2bids.py
@@ -84,7 +84,7 @@ def print_summary(filename, ntp_expected, ntp_found, samp_freq, time_offset, out
                f'Tip: Time 0 is the time of first trigger\n'
                f'------------------------------------------------\n')
     LGR.info(summary)
-    utils.writefile(outfile, '.log', summary)
+    utils.write_file(outfile, '.log', summary)
 
 
 def print_json(outfile, samp_freq, time_offset, ch_name):

--- a/phys2bids/tests/test_utils.py
+++ b/phys2bids/tests/test_utils.py
@@ -78,12 +78,12 @@ def test_copy_file(tmpdir):
     utils.copy_file(test_old_path, test_new_path, ext)
 
 
-# Tests writefile
-def test_writefile(tmpdir):
+# Tests write_file
+def test_write_file(tmpdir):
     ext = '.txt'
     test_old_path = tmpdir.join('foo.txt')
     test_text = 'Wubba lubba dub dub!'
-    utils.writefile(test_old_path, ext, test_text)
+    utils.write_file(test_old_path, ext, test_text)
 
 
 # Tests writejson

--- a/phys2bids/utils.py
+++ b/phys2bids/utils.py
@@ -209,7 +209,7 @@ def copy_file(oldpath, newpath, ext=''):
     cp(oldpath + ext, newpath + ext)
 
 
-def writefile(filename, ext, text):
+def write_file(filename, ext, text):
     """
     Produce a textfile of the specified extension `ext`.
 


### PR DESCRIPTION
Closes #332 

## Proposed Changes

  - Rename the function
  - Update tests
  - Update all uses of the function throughout the package

Didn't update the API page of docs since apparently there isn't one for utils