### PR TITLE
Add Python 3.8 and 3.9

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,3 +16,9 @@ jobs:
       py37-x64:
         PYTHON_VERSION: '3.7'
         PYTHON_ARCH: 'x64'
+      py37-x64:
+        PYTHON_VERSION: '3.8'
+        PYTHON_ARCH: 'x64'
+      py37-x64:
+        PYTHON_VERSION: '3.9'
+        PYTHON_ARCH: 'x64'

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,8 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 license = Apache-2.0
 description = Python library to convert physiological data files into BIDS format
 long_description = file:README.md


### PR DESCRIPTION
- added testing on 3.8 and 3.8 only for azure ATM
- [ ] decide either desired to duplicate sections further in circle setup for 3.8 and/or 3.9