### PR TITLE
Add support (and tests) for python 3.8 and 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,144 +6,102 @@ version: 2.1
 orbs:
   codecov: codecov/codecov@1.0.5
 jobs:
-
-  makeenv_37:
+  makeenv:
+    parameters:
+      python-version:
+        type: string
     docker:
       - image: continuumio/miniconda3
     working_directory: /tmp/src/phys2bids
     steps:
       - checkout
+      - run:
+          name: "Setup convenience short env var PYVER"
+          command: echo "export PYVER=\"<< parameters.python-version >>\"" >> $BASH_ENV
       - persist_to_workspace:
           root: /tmp
           paths:
               - src/phys2bids
       - restore_cache:
-          key: conda-py37-v1-{{ checksum "setup.cfg" }}
+          key: conda-<< parameters.python-version >>-v1-{{ checksum "setup.cfg" }}
       - run:
           name: Generate environment
           command: |
-            if [[ -e /opt/conda/envs/py36_env ]]; then
+            if [[ -e /opt/conda/envs/${PYVER} ]]; then
               echo "Restoring environment from cache"
-                source activate phys2bids_py37
+                source activate $PYVER
             else
-              conda create -yq -n phys2bids_py37 python=3.7
-              source activate phys2bids_py37
+              conda create -yq -n $PYVER python=$PYVER
+              source activate $PYVER
               pip install -e ".[test,doc]"
             fi
       - save_cache:
-          key: conda-py37-v1-{{ checksum "setup.cfg" }}
+          key: conda-<< parameters.python-version >>-v1-{{ checksum "setup.cfg" }}
           paths:
-              - /opt/conda/envs/phys2bids_py37
+              - /opt/conda/envs/<< parameters.python-version >>
 
-  unittest_36:
+  unittest:
+    parameters:
+      python-version:
+        type: string
     docker:
       - image: continuumio/miniconda3
     working_directory: /tmp/src/phys2bids
     steps:
       - checkout
-      - restore_cache:
-          key: conda-py36-v1-{{ checksum "setup.cfg" }}
       - run:
-          name: Generate environment
+          name: "Setup convenience short env var PYVER"
+          command: echo "export PYVER=\"<< parameters.python-version >>\"" >> $BASH_ENV
+      - restore_cache:
+          key: conda-<< parameters.python-version >>-v1-{{ checksum "setup.cfg" }}
+      - run:
+          name: Install extra dependencies
           command: |
             apt-get install -yqq make
-            if [ ! -d /opt/conda/envs/phys2bids_py36 ]; then
-              conda create -yq -n phys2bids_py36 python=3.6
-              source activate phys2bids_py36
-              pip install -e ".[test]"
-            fi
       - run:
-          name: Running unit tests
+          name: Run unit tests
           command: |
-            source activate phys2bids_py36
+            source activate $PYVER
             make unittest
             mkdir /tmp/src/coverage
-            mv /tmp/src/phys2bids/.coverage /tmp/src/coverage/.coverage.py36
-      - save_cache:
-          key: conda-py36-v1-{{ checksum "setup.cfg" }}
-          paths:
-              - /opt/conda/envs/phys2bids_py36
+            mv /tmp/src/phys2bids/.coverage /tmp/src/coverage/.coverage.py$PYVER
       - persist_to_workspace:
           root: /tmp
           paths:
-              - src/coverage/.coverage.py36
+              - src/coverage/.coverage.py<< parameters.python-version >>
 
-  unittest_37:
+  integrationtest:
+    parameters:
+      python-version:
+        type: string
     docker:
       - image: continuumio/miniconda3
     working_directory: /tmp/src/phys2bids
     steps:
       - checkout
-      - restore_cache:
-          key: conda-py37-v1-{{ checksum "setup.cfg" }}
       - run:
-          name: Running unit tests
-          command: |
-            apt-get install -y make
-            source activate phys2bids_py37  # depends on makeenv_37
-            make unittest
-            mkdir /tmp/src/coverage
-            mv /tmp/src/phys2bids/.coverage /tmp/src/coverage/.coverage.py37
-      - persist_to_workspace:
-          root: /tmp
-          paths:
-              - src/coverage/.coverage.py37
-
-  integrationtest_36:
-    docker:
-      - image: continuumio/miniconda3
-    working_directory: /tmp/src/phys2bids
-    steps:
-      - checkout
+          name: "Setup convenience short env var PYVER"
+          command: echo "export PYVER=\"<< parameters.python-version >>\"" >> $BASH_ENV
       - restore_cache:
-          key: conda-py36-v1-{{ checksum "setup.cfg" }}
+          key: conda-<< parameters.python-version >>-v1-{{ checksum "setup.cfg" }}
       - run:
-          name: Generate environment
+          name: Install extra dependencies
           command: |
             apt-get install -yqq make
-            if [ ! -d /opt/conda/envs/phys2bids_py36 ]; then
-              conda create -yq -n phys2bids_py36 python=3.6
-              source activate phys2bids_py36
-              pip install -e ".[test]"
-            fi
       - run:
           name: Run integration tests
           no_output_timeout: 10m
           command: |
-            source activate phys2bids_py36
+            source activate $PYVER
             make integration
             mkdir /tmp/src/coverage
-            mv /tmp/src/phys2bids/.coverage /tmp/src/coverage/.coverage.integration36
+            mv /tmp/src/phys2bids/.coverage /tmp/src/coverage/.coverage.integration$PYVER
       - store_artifacts:
           path: /tmp/data
       - persist_to_workspace:
           root: /tmp
           paths:
-              - src/coverage/.coverage.integration36
-
-  integrationtest_37:
-    docker:
-      - image: continuumio/miniconda3
-    working_directory: /tmp/src/phys2bids
-    steps:
-      - checkout
-      - restore_cache:
-          key: conda-py37-v1-{{ checksum "setup.cfg" }}
-      - run:
-          name: Run integration tests
-          no_output_timeout: 10m
-          command: |
-            apt-get install -yqq make
-            source activate phys2bids_py37  # depends on makeenv_37
-            make integration
-            mkdir /tmp/src/coverage
-            mv /tmp/src/phys2bids/.coverage /tmp/src/coverage/.coverage.integration37
-      - store_artifacts:
-          path: /tmp/data
-      - persist_to_workspace:
-          root: /tmp
-          paths:
-              - src/coverage/.coverage.integration37
+              - src/coverage/.coverage.integration<< parameters.python-version >>
 
   style_check:
     docker:
@@ -152,12 +110,12 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: conda-py37-v1-{{ checksum "setup.cfg" }}
+          key: conda-3.7-v1-{{ checksum "setup.cfg" }}
       - run:
           name: Style check
           command: |
             apt-get install -yqq make
-            source activate phys2bids_py37  # depends on makeenv37
+            source activate 3.7
             make lint
       - store_artifacts:
           path: /tmp/data/lint
@@ -170,12 +128,12 @@ jobs:
       - attach_workspace:  # get phys2bids
           at: /tmp
       - restore_cache:  # load environment
-          key: conda-py37-v1-{{ checksum "setup.cfg" }}
+          key: conda-3.7-v1-{{ checksum "setup.cfg" }}
       - run:
           name: Build documentation
           command: |
             apt-get install -yqq make
-            source activate phys2bids_py37  # depends on makeenv_37
+            source activate 3.7
             make -C docs html
       - store_artifacts:
           path: /tmp/src/phys2bids/docs/_build/html
@@ -189,12 +147,12 @@ jobs:
           at: /tmp
       - checkout
       - restore_cache:
-          key: conda-py37-v1-{{ checksum "setup.cfg" }}
+          key: conda-3.7-v1-{{ checksum "setup.cfg" }}
       - run:
           name: Merge coverage files
           command: |
             apt-get install -yqq curl
-            source activate phys2bids_py37  # depends on makeenv37
+            source activate 3.7
             cd /tmp/src/coverage/
             coverage combine
             coverage xml
@@ -207,25 +165,33 @@ workflows:
   version: 2.1
   build_test:
     jobs:
-      - makeenv_37
-      - unittest_36
-      - unittest_37:
+      - makeenv:
+          name: makeenv-<< matrix.python-version >>
+          matrix:
+            parameters:
+              python-version: ["3.6", "3.7"]
+      - unittest:
+          name: unittest-<< matrix.python-version >>
+          matrix:
+            parameters:
+              python-version: ["3.6", "3.7"]
           requires:
-            - makeenv_37
-      - integrationtest_36
-      - integrationtest_37:
+            - makeenv-<< matrix.python-version >>
+      - integrationtest:
+          name: integrationtest-<< matrix.python-version >>
+          matrix:
+            parameters:
+              python-version: ["3.6", "3.7"]
           requires:
-            - makeenv_37
+            - makeenv-<< matrix.python-version >>
       - style_check:
           requires:
-            - makeenv_37
+            - makeenv-3.7
       - build_docs:
           requires:
-            - makeenv_37
+            - makeenv-3.7
       - merge_coverage:
           requires:
-            - unittest_36
-            - unittest_37
-            - integrationtest_36
-            - integrationtest_37
+            - unittest
+            - integrationtest
             - style_check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,19 +169,19 @@ workflows:
           name: makeenv-<< matrix.python-version >>
           matrix:
             parameters:
-              python-version: ["3.6", "3.7"]
+              python-version: ["3.6", "3.7", "3.8", "3.9"]
       - unittest:
           name: unittest-<< matrix.python-version >>
           matrix:
             parameters:
-              python-version: ["3.6", "3.7"]
+              python-version: ["3.6", "3.7", "3.8", "3.9"]
           requires:
             - makeenv-<< matrix.python-version >>
       - integrationtest:
           name: integrationtest-<< matrix.python-version >>
           matrix:
             parameters:
-              python-version: ["3.6", "3.7"]
+              python-version: ["3.6", "3.7", "3.8", "3.9"]
           requires:
             - makeenv-<< matrix.python-version >>
       - style_check:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,3 +16,9 @@ jobs:
       py37-x64:
         PYTHON_VERSION: '3.7'
         PYTHON_ARCH: 'x64'
+      py37-x64:
+        PYTHON_VERSION: '3.8'
+        PYTHON_ARCH: 'x64'
+      py37-x64:
+        PYTHON_VERSION: '3.9'
+        PYTHON_ARCH: 'x64'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ jobs:
       py37-x64:
         PYTHON_VERSION: '3.7'
         PYTHON_ARCH: 'x64'
-      py37-x64:
+      py38-x64:
         PYTHON_VERSION: '3.8'
         PYTHON_ARCH: 'x64'
       py39-x64:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,6 @@ jobs:
       py37-x64:
         PYTHON_VERSION: '3.8'
         PYTHON_ARCH: 'x64'
-      py37-x64:
+      py39-x64:
         PYTHON_VERSION: '3.9'
         PYTHON_ARCH: 'x64'

--- a/phys2bids/io.py
+++ b/phys2bids/io.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+"""phys2bids interfaces for txt  and acq extension files."""
 
 import logging
 from collections import Counter
@@ -12,8 +13,6 @@ from bioread import read_file
 from phys2bids.physio_obj import BlueprintInput
 
 LGR = logging.getLogger(__name__)
-
-"""phys2bids interfaces for txt  and acq extension files."""
 
 
 def check_multifreq(timeseries, freq, start=0, leftout=0):

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,8 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 license = Apache-2.0
 description = Python library to convert physiological data files into BIDS format
 long_description = file:README.md


### PR DESCRIPTION
It is really mostly a blind attempt since I have little to no circle experience,
and surprisingly I have failed to find a good python-oriented example upon
a quick search, so just read a bit on matrix specs.  Some notes

+ added testing against 3.8 and 3.9
- I decided to not bother with non-important here prefixes to the environment
  names etc to harmonize it all.  I guess they could be returned if necessary
  but would require extending the boiler plate
- ~~I have changed "activate" to "conda activate" since AFAIK that is how
  it should be~~ (would need all the bashrc setup, bleh)
- If it all fails -- it might still be not my fault! since with extensive
  caching of environments I wonder if such as CI setup would stick to stale
  caches (no setup.cfg changes) while dependencies would progress forward
  thus possibly introducing regressions which would go unnoticed.
- matrix is still specified in multiple places -- may be somehow could be reduced more?

It is unlikely that this RF "just works", but I am an optimist.

If it doesn't work -- feel free to push it forward or just redo from scratch.

Whenever this is done, could be a nice addition on top of #352  ;-)

## Change Type
- [x] `refactoring` (no version update)
