### PR TITLE
Add additional automatic detection of the trigger based on time-domain analysis

### DIFF
--- a/phys2bids/phys2bids.py
+++ b/phys2bids/phys2bids.py
@@ -252,10 +252,6 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
     if ch_name:
         LGR.info('Renaming channels with given names')
         phys_in.rename_channels(ch_name)
-    else:
-        LGR.info('Renaming channels automatically')
-        phys_in.auto_rename_channels()
-
 
     # Checking acquisition type via user's input
     if tr is not None and num_timepoints_expected is not None:

--- a/phys2bids/phys2bids.py
+++ b/phys2bids/phys2bids.py
@@ -192,8 +192,8 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
     # Check options to make them internally coherent pt. II
     # #!# This can probably be done while parsing?
     indir = os.path.abspath(indir)
-    if chtrig < 1:
-        raise Exception('Wrong trigger channel. Channel indexing starts with 1!')
+    if chtrig < 0:
+        raise Exception('Wrong trigger channel. Channel indexing starts with 0!')
     filename, ftype = utils.check_input_type(filename,
                                              indir)
 

--- a/phys2bids/phys2bids.py
+++ b/phys2bids/phys2bids.py
@@ -252,6 +252,10 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
     if ch_name:
         LGR.info('Renaming channels with given names')
         phys_in.rename_channels(ch_name)
+    else:
+        LGR.info('Renaming channels automatically')
+        phys_in.auto_rename_channels()
+
 
     # Checking acquisition type via user's input
     if tr is not None and num_timepoints_expected is not None:

--- a/phys2bids/physio_obj.py
+++ b/phys2bids/physio_obj.py
@@ -601,7 +601,7 @@ class BlueprintInput():
             # Normalize each signal to [0,1]
             min_ts = np.min(channel_ts, axis=1)[:, None]
             max_ts = np.max(channel_ts, axis=1)[:, None]
-            channel_ts = (channel_ts - min_ts)/(max_ts - min_ts)
+            channel_ts = (channel_ts - min_ts) / (max_ts - min_ts)
 
             # Compute distance to the closest signal limit (0 or 1)
             distance = np.minimum(abs(channel_ts - 0), abs(channel_ts - 1))

--- a/phys2bids/physio_obj.py
+++ b/phys2bids/physio_obj.py
@@ -555,7 +555,8 @@ class BlueprintInput():
 
     def auto_trigger_selection(self):
         """
-        Find a trigger index matching the channels with a regular expresion.
+        Find a trigger index matching the channels with a regular expresion or
+        by using a time-domain recognition of the trigger.
 
         It compares the channel name with the the regular expressions stored
         in TRIGGER_NAMES. If that fails a time-domain recognition of the

--- a/phys2bids/physio_obj.py
+++ b/phys2bids/physio_obj.py
@@ -608,7 +608,7 @@ class BlueprintInput():
             distance_mean = np.mean(distance, axis=1)
 
             # Set the trigger as the channel with the smallest distance
-            self.trigger_idx = np.argmin(distance_mean) + 1
+            self.trigger_idx = np.nanargmin(distance_mean) + 1
 
         LGR.info(f'{self.ch_name[self.trigger_idx]} selected as trigger channel')
 

--- a/phys2bids/physio_obj.py
+++ b/phys2bids/physio_obj.py
@@ -555,8 +555,7 @@ class BlueprintInput():
 
     def auto_trigger_selection(self):
         """
-        Find a trigger index matching the channels with a regular expresion or
-        by using a time-domain recognition of the trigger.
+        Find a trigger index automatically.
 
         It compares the channel name with the the regular expressions stored
         in TRIGGER_NAMES. If that fails a time-domain recognition of the
@@ -596,17 +595,17 @@ class BlueprintInput():
         else:
             # Time-domain automatic trigger detection
             # Initialize distance array
-            mean_d = [np.nan]*(self.ch_amount-1)
+            mean_d = [np.nan] * (self.ch_amount - 1)
             # Loop through channels
             for n in range(1, self.ch_amount):
                 # Get timeseries
                 s = self.timeseries[n]
                 # Normalize to [0,1]
-                s = (s - min(s))/(max(s) - min(s))
+                s = (s - min(s)) / (max(s) - min(s))
                 # Calculate distance to the closest signal limit (min or max)
                 d = np.minimum(abs(s - max(s)), abs(s - min(s)))
                 # Store the mean distance
-                mean_d[n-1] = np.mean(d)
+                mean_d[n - 1] = np.mean(d)
 
             # Set the trigger as the channel with smaller distance
             self.trigger_idx = np.argmin(mean_d) + 1

--- a/phys2bids/tests/test_phys2bids.py
+++ b/phys2bids/tests/test_phys2bids.py
@@ -47,7 +47,7 @@ def test_print_json(tmpdir):
 def test_raise_exception(samefreq_full_acq_file):
     test_path, test_filename = os.path.split(samefreq_full_acq_file)
     with raises(Exception) as errorinfo:
-        phys2bids.phys2bids(filename=test_filename, indir=test_path, outdir=test_path, chtrig=0)
+        phys2bids.phys2bids(filename=test_filename, indir=test_path, outdir=test_path, chtrig=-1)
     assert 'Wrong trigger' in str(errorinfo.value)
 
     with raises(Exception) as errorinfo:

--- a/phys2bids/tests/test_physio_obj.py
+++ b/phys2bids/tests/test_physio_obj.py
@@ -291,7 +291,7 @@ def test_auto_trigger_selection_text(caplog):
         assert 'More than one possible trigger channel' in str(errorinfo.value)
 
 
-def test_auto_trigger_selection_time(caplog):
+def test_auto_trigger_selection_time():
     """Test auto_trigger_selection in time domain."""
     # Simulate 10 s of a trigger, O2 and ECG
     T = 10

--- a/phys2bids/tests/test_physio_obj.py
+++ b/phys2bids/tests/test_physio_obj.py
@@ -284,12 +284,6 @@ def test_auto_trigger_selection(caplog):
                                 test_units, test_chtrig)
     assert phys_in.trigger_idx == 1
     # test when no trigger is found
-    test_chn_name = ['time', 'TRIGGAH', 'half', 'CO2', 'CO 2', 'strigose']
-    with raises(Exception) as errorinfo:
-        phys_in = po.BlueprintInput(test_timeseries, test_freq, test_chn_name,
-                                    test_units, test_chtrig)
-        assert 'No trigger channel automatically found' in str(errorinfo.value)
-    # test when no trigger is found
     test_chn_name = ['time', 'trigger', 'TRIGGER', 'CO2', 'CO 2', 'strigose']
     with raises(Exception) as errorinfo:
         phys_in = po.BlueprintInput(test_timeseries, test_freq, test_chn_name,

--- a/phys2bids/tests/test_physio_obj.py
+++ b/phys2bids/tests/test_physio_obj.py
@@ -261,7 +261,7 @@ def test_BlueprintOutput():
     assert blueprint_out == blueprint_out
 
 
-def test_auto_trigger_selection(caplog):
+def test_auto_trigger_selection_text(caplog):
     """Test auto_trigger_selection."""
     test_time = np.array([0, 1, 2, 3, 4])
     test_trigger = np.array([0, 1, 2, 3, 4])
@@ -289,3 +289,31 @@ def test_auto_trigger_selection(caplog):
         phys_in = po.BlueprintInput(test_timeseries, test_freq, test_chn_name,
                                     test_units, test_chtrig)
         assert 'More than one possible trigger channel' in str(errorinfo.value)
+
+
+def test_auto_trigger_selection_time(caplog):
+    """Test auto_trigger_selection in time domain."""
+    # Simulate 10 s of a trigger, O2 and ECG
+    T = 10
+    nSamp = 100
+    fs = nSamp/T
+    test_time = np.linspace(0, T, nSamp)
+    test_freq = [fs, fs, fs, fs]
+
+    # O2 as a sinusoidal of 0.5 Hz
+    test_O2 = np.sin(2*np.pi*0.5*test_time)
+    # ECG as a sinusoidal with 1.5 Hz
+    test_ecg = np.sin(2*np.pi*1.5*test_time)
+    # Trigger as a binary signal
+    test_trigger = np.zeros(nSamp)
+    test_trigger[1:nSamp:4] = 1
+
+    test_timeseries = [test_time, test_O2, test_ecg, test_trigger]
+    test_chn_name = ['time', 'O2', 'ecg', 'tiger']
+    test_units = ['s', 'V', 'V', 'V']
+
+    # test when trigger is 0 and the trigger is not recognized by text matching:
+    test_chtrig = 0
+    phys_in = po.BlueprintInput(test_timeseries, test_freq, test_chn_name,
+                                test_units, test_chtrig)
+    assert phys_in.trigger_idx == 3

--- a/phys2bids/tests/test_physio_obj.py
+++ b/phys2bids/tests/test_physio_obj.py
@@ -312,7 +312,7 @@ def test_auto_trigger_selection_time():
     test_chn_name = ['time', 'O2', 'ecg', 'tiger']
     test_units = ['s', 'V', 'V', 'V']
 
-    # test when trigger is 0 and the trigger is not recognized by text matching:
+    # test when chtrig is 0 and the trigger is not recognized by text matching:
     test_chtrig = 0
     phys_in = po.BlueprintInput(test_timeseries, test_freq, test_chn_name,
                                 test_units, test_chtrig)


### PR DESCRIPTION
<!-- Write all of the issues that are linked to this pull request. -->
<!-- If this PR is enough to close them you can write something like "Closes #314 and closes #42" -->
<!-- If you just want to reference them without closing them, you can add something like "References #112" -->
Related to #204 and #386. 

<!-- Add a short description of the PR content here-->
This implements a time-domain detection of the trigger when the text-matching detection fails.
## Proposed Changes
<!-- List major points of changes here, so that the reviewers can have a bit more context while looking at your work! -->
  - **Added a time-domain detection of the trigger**
The implementation computes a metric measuring how much each channel differs from a binary signal. The metric is computed as the average distance from each point to the closest limit of the signal (min or max). 
More "binary-like" signals like the trigger should have most of the points closer to either signal limit resulting on a smaller metric. Assuming this,  the trigger is detected as the channel that minimizes the metric.

Changes regarding the chtrig=0 are part of #390 (hope it is not confusing).

## Change Type
<!-- Indicate the type of change you think your pull request is -->
- [ ] `bugfix` (+0.0.1)
- [x] `minor` (+0.1.0)
- [ ] `major`  (+1.0.0)
- [ ] `refactoring` (no version update)
- [ ] `test` (no version update)
- [ ] `infrastructure` (no version update)
- [ ] `documentation` (no version update)
- [ ] `other`

## Checklist before review
<!-- If this section is not clear, please read this part of the docs: https://phys2bids.readthedocs.io/en/latest/contributorfile.html#pr -->
<!-- You're invited to open a draft PR ASAP, but before marking it "ready for review", check that you have done the following: -->
- [x] I added everything I wanted to add to this PR.
- [x] \[Code or tests only\] I wrote/updated the necessary docstrings.
- [x] \[Code or tests only\] I ran and passed tests locally.
- [ ] \[Documentation only\] I built the docs locally.
- [x] My contribution is harmonious with the rest of the code: I'm not introducing repetitions.
- [x] My code respects the adopted style, especially linting conventions.
- [x] The title of this PR is explanatory on its own, enough to be understood as part of a changelog.
- [ ] I added or indicated the right labels.
<!-- If relevant, you can add a milestone label or indicate an ideal timeline for this PR, including whether the progress of this PR is linked to other PRs being completed before or after it. -->
- [ ] I added information regarding the timeline of completion for this PR.
<!-- If you want, you can ask for reviews on a draft PR -->
- [ ] Please, comment on my PR while it's a draft and give me feedback on the development!
