### PR TITLE
Define previously unspecified Exceptions in the main workflow

### DIFF
--- a/phys2bids/phys2bids.py
+++ b/phys2bids/phys2bids.py
@@ -141,8 +141,8 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
 
     Raises
     ------
-    NotImplementedError
-        If the file extension is not supported yet.
+    RuntimeError[NotImplementedError]
+        If invalid input data is provided or if the file extension is not supported yet.
     """
     # Check options to make them internally coherent pt. I
     # #!# This can probably be done while parsing?
@@ -193,7 +193,7 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
     # #!# This can probably be done while parsing?
     indir = os.path.abspath(indir)
     if chtrig < 0:
-        raise Exception('Wrong trigger channel. Channel indexing starts with 0!')
+        raise RuntimeError('Wrong trigger channel. Channel indexing starts with 0!')
     filename, ftype = utils.check_input_type(filename,
                                              indir)
 
@@ -212,9 +212,9 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
     if tr is not None and num_timepoints_expected is not None:
         # If tr and ntp were specified, check that tr is either length one or ntp.
         if len(num_timepoints_expected) != len(tr) and len(tr) != 1:
-            raise Exception('Number of sequence types listed with TR '
-                            'doesn\'t match expected number of runs in '
-                            'the session')
+            raise RuntimeError('Number of sequence types listed with TR '
+                               'doesn\'t match expected number of runs in '
+                               'the session')
 
     # Read file!
     LGR.info(f'Reading the file {infile}')
@@ -272,7 +272,7 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
             # Check that sum of tp expected is equivalent to num_timepoints_found,
             # if it passes call slice4phys
             if phys_in.num_timepoints_found != sum(num_timepoints_expected):
-                raise Exception('The number of triggers found is different '
+                raise NotImplementedError('The number of triggers found is different '
                                 'than expected. Better stop now than break '
                                 'something.')
 

--- a/phys2bids/phys2bids.py
+++ b/phys2bids/phys2bids.py
@@ -272,9 +272,9 @@ def phys2bids(filename, info=False, indir='.', outdir='.', heur_file=None,
             # Check that sum of tp expected is equivalent to num_timepoints_found,
             # if it passes call slice4phys
             if phys_in.num_timepoints_found != sum(num_timepoints_expected):
-                raise NotImplementedError('The number of triggers found is different '
-                                'than expected. Better stop now than break '
-                                'something.')
+                raise RuntimeError('The number of triggers found is different '
+                                   'than expected. Better stop now than break '
+                                   'something.')
 
             # slice the recording based on user's entries
             # !!! ATTENTION: PHYS_IN GETS OVERWRITTEN AS DICTIONARY


### PR DESCRIPTION
A very broad Exception was raised, which makes it hard to catch. Now two kind of exceptions are raised, 1) RuntimeError for invalid input data and 2) NotImplementedError if that is the case (before the broad 'Exception' base-class was raised)

## Proposed Changes
raise Exception() -> raise RuntimeError / NotImplementedError

## Change Type
<!-- Indicate the type of change you think your pull request is -->
- [x] `bugfix` (+0.0.1)
- [x] `minor` (+0.1.0)
- [ ] `major`  (+1.0.0)
- [ ] `refactoring` (no version update)
- [ ] `test` (no version update)
- [ ] `infrastructure` (no version update)
- [ ] `documentation` (no version update)
- [ ] `other`

## Checklist before review
- [x] I added everything I wanted to add to this PR.
- [ ] \[Code or tests only\] I wrote/updated the necessary docstrings.
- [ ] \[Code or tests only\] I ran and passed tests locally.
- [ ] \[Documentation only\] I built the docs locally.
- [x] My contribution is harmonious with the rest of the code: I'm not introducing repetitions.
- [x] My code respects the adopted style, especially linting conventions.
- [x] The title of this PR is explanatory on its own, enough to be understood as part of a changelog.
- [x] I added or indicated the right labels.
- [ ] I added information regarding the timeline of completion for this PR.
- [x] Please, comment on my PR while it's a draft and give me feedback on the development!
