### PR TITLE
Fix channel trigger variable type when the trigger is automatically detected 

### DIFF
--- a/phys2bids/physio_obj.py
+++ b/phys2bids/physio_obj.py
@@ -605,7 +605,7 @@ class BlueprintInput():
                 raise Exception('More than one possible trigger channel was automatically found. '
                                 'Please run phys2bids specifying the -chtrig argument.')
             else:
-                self.trigger_idx = indexes[0]
+                self.trigger_idx = int(indexes[0])
         else:
             # Time-domain automatic trigger detection
             LGR.info('Find the trigger channel by measuring data distance from its value limits.')

--- a/phys2bids/physio_obj.py
+++ b/phys2bids/physio_obj.py
@@ -590,6 +590,7 @@ class BlueprintInput():
                 Automatically retrieved trigger index
         """
         LGR.info('Running automatic trigger detection.')
+        LGR.info('Matching channel names with known trigger names first.')
         joint_match = '§'.join(TRIGGER_NAMES)
         indexes = []
         for n, case in enumerate(self.ch_name):
@@ -607,7 +608,7 @@ class BlueprintInput():
                 self.trigger_idx = indexes[0]
         else:
             # Time-domain automatic trigger detection
-
+            LGR.info('Find the trigger channel by measuring data distance from its value limits.')
             # Create numpy array with all channels (excluding time)
             channel_ts = np.array(self.timeseries[1:])
 
@@ -621,7 +622,7 @@ class BlueprintInput():
             distance_mean = np.mean(distance, axis=1)
 
             # Set the trigger as the channel with the smallest distance
-            self.trigger_idx = np.nanargmin(distance_mean) + 1
+            self.trigger_idx = int(np.nanargmin(distance_mean) + 1)
 
         LGR.info(f'{self.ch_name[self.trigger_idx]} selected as trigger channel')
 


### PR DESCRIPTION
<!-- Write all of the issues that are linked to this pull request. -->
<!-- If this PR is enough to close them you can write something like "Closes #314 and closes #42" -->
<!-- If you just want to reference them without closing them, you can add something like "References #112" -->
Closes #

<!-- Add a short description of the PR content here-->
This PR fixes a bug that appears when slice4phys interacts with automatic trigger detection.
Before, automatic rigger detection was not forcing the trigger channel number variable to be an integer. This PR changes that.

## Proposed Changes
<!-- List major points of changes here, so that the reviewers can have a bit more context while looking at your work! -->
  -
  -
  -

## Change Type
<!-- Indicate the type of change you think your pull request is -->
- [ ] `bugfix` (+0.0.1)
- [ ] `minor` (+0.1.0)
- [ ] `major`  (+1.0.0)
- [ ] `refactoring` (no version update)
- [ ] `test` (no version update)
- [ ] `infrastructure` (no version update)
- [ ] `documentation` (no version update)
- [ ] `other`

## Checklist before review
<!-- If this section is not clear, please read this part of the docs: https://phys2bids.readthedocs.io/en/latest/contributorfile.html#pr -->
<!-- You're invited to open a draft PR ASAP, but before marking it "ready for review", check that you have done the following: -->
- [ ] I added everything I wanted to add to this PR.
- [ ] \[Code or tests only\] I wrote/updated the necessary docstrings.
- [ ] \[Code or tests only\] I ran and passed tests locally.
- [ ] \[Documentation only\] I built the docs locally.
- [ ] My contribution is harmonious with the rest of the code: I'm not introducing repetitions.
- [ ] My code respects the adopted style, especially linting conventions.
- [ ] The title of this PR is explanatory on its own, enough to be understood as part of a changelog.
- [ ] I added or indicated the right labels.
<!-- If relevant, you can add a milestone label or indicate an ideal timeline for this PR, including whether the progress of this PR is linked to other PRs being completed before or after it. -->
- [ ] I added information regarding the timeline of completion for this PR.
<!-- If you want, you can ask for reviews on a draft PR -->
- [ ] Please, comment on my PR while it's a draft and give me feedback on the development!
