### PR TITLE
Improve performance by using numpy for trigger detection and closing matplotlib figures to avoid memleaks.

### DIFF
--- a/phys2bids/physio_obj.py
+++ b/phys2bids/physio_obj.py
@@ -524,7 +524,6 @@ class BlueprintInput:
             thr = np.mean(trigger)
             flag = 1
         timepoints = trigger > thr
-        # way more efficient alternative
         num_timepoints_found = np.count_nonzero(np.ediff1d(timepoints.astype(np.int8)) > 0)
         if flag == 1:
             LGR.info(

--- a/phys2bids/physio_obj.py
+++ b/phys2bids/physio_obj.py
@@ -524,9 +524,8 @@ class BlueprintInput:
             thr = np.mean(trigger)
             flag = 1
         timepoints = trigger > thr
-        num_timepoints_found = len(
-            [is_true for is_true, _ in groupby(timepoints, lambda x: x != 0) if is_true]
-        )
+        # way more efficient alternative
+        num_timepoints_found = np.count_nonzero(np.ediff1d(timepoints.astype(np.int8)) > 0)
         if flag == 1:
             LGR.info(
                 f"The number of timepoints according to the std_thr method "

--- a/phys2bids/tests/test_viz.py
+++ b/phys2bids/tests/test_viz.py
@@ -20,6 +20,7 @@ def test_plot_all(samefreq_full_acq_file):
     assert os.path.isfile(
         os.path.join(test_path, os.path.splitext(os.path.basename(test_filename))[0] + ".png")
     )
+    assert len(viz.plt.get_fignums()) == 0, "plots are not closed, this can cause memory leaks"
 
 
 # Expected to fail due to trigger plot issue
@@ -33,3 +34,4 @@ def test_plot_trigger(samefreq_full_acq_file):
         phys_obj.timeseries[0], phys_obj.timeseries[chtrig], out, 1.5, 1.6, 60, test_filename
     )
     assert os.path.isfile(out + "_trigger_time.png")
+    assert len(viz.plt.get_fignums()) == 0, "plots are not closed, this can cause memory leaks"

--- a/phys2bids/viz.py
+++ b/phys2bids/viz.py
@@ -267,3 +267,5 @@ def plot_all(ch_name, timeseries, units, freq, infile, outfile, dpi=SET_DPI, siz
     outfile = os.path.join(outfile, os.path.splitext(os.path.basename(infile))[0] + ".png")
     LGR.info(f"saving channel plot to {outfile}")
     fig.savefig(outfile, dpi=dpi, bbox_inches="tight")
+    fig.clf()
+    plt.close('all')

--- a/phys2bids/viz.py
+++ b/phys2bids/viz.py
@@ -267,5 +267,4 @@ def plot_all(ch_name, timeseries, units, freq, infile, outfile, dpi=SET_DPI, siz
     outfile = os.path.join(outfile, os.path.splitext(os.path.basename(infile))[0] + ".png")
     LGR.info(f"saving channel plot to {outfile}")
     fig.savefig(outfile, dpi=dpi, bbox_inches="tight")
-    fig.clf()
-    plt.close("all")
+    plt.close()

--- a/phys2bids/viz.py
+++ b/phys2bids/viz.py
@@ -268,4 +268,4 @@ def plot_all(ch_name, timeseries, units, freq, infile, outfile, dpi=SET_DPI, siz
     LGR.info(f"saving channel plot to {outfile}")
     fig.savefig(outfile, dpi=dpi, bbox_inches="tight")
     fig.clf()
-    plt.close('all')
+    plt.close("all")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy>=1.10, <1.24
 matplotlib >=3.1.1, !=3.3.0rc1
 PyYAML >=5.1, !=*rc*
-pymatreader

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ numpy>=1.10, <1.24
 matplotlib >=3.1.1, !=3.3.0rc1
 PyYAML >=5.1, !=*rc*
 pymatreader
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 numpy>=1.10, <1.24
 matplotlib >=3.1.1, !=3.3.0rc1
 PyYAML >=5.1, !=*rc*
+pymatreader
+


### PR DESCRIPTION
<!-- Write all of the issues that are linked to this pull request. -->
<!-- If this PR is enough to close them you can write something like "Closes #314 and closes #42" -->
<!-- If you just want to reference them without closing them, you can add something like "References #112" -->


<!-- Add a short description of the PR content here-->
cutting acq files into runs lead to very unreasonably large memory usage, and long runtime.
After memory and time profiling here are the proposed changes.
I ran the test locally and some crashed but do not seem related to my changes. I fixed one of the fail test by adding the missing requirements. 

## Proposed Changes
<!-- List major points of changes here, so that the reviewers can have a bit more context while looking at your work! -->
  - properly close matplotlib figures after rendering/saving to avoid clogging memory
  - replace loop-based trigger counting with a more (100-fold) efficient numpy-based one. 
  - fix requirements to have some failing test passing

## Change Type
<!-- Indicate the type of change you think your pull request is -->
- [ ] `bugfix` (+0.0.1)
- [x] `minor` (+0.1.0)
- [ ] `major`  (+1.0.0)
- [ ] `refactoring` (no version update)
- [ ] `test` (no version update)
- [ ] `infrastructure` (no version update)
- [ ] `documentation` (no version update)
- [ ] `other`

## Checklist before review
<!-- If this section is not clear, please read this part of the docs: https://phys2bids.readthedocs.io/en/latest/contributorfile.html#pr -->
<!-- You're invited to open a draft PR ASAP, but before marking it "ready for review", check that you have done the following: -->
- [ ] I added everything I wanted to add to this PR.
- [ ] \[Code or tests only\] I wrote/updated the necessary docstrings.
- [x] \[Code or tests only\] I ran and passed tests locally. 
- [ ] \[Documentation only\] I built the docs locally.
- [x] My contribution is harmonious with the rest of the code: I'm not introducing repetitions.
- [ ] My code respects the adopted style, especially linting conventions.
- [ ] The title of this PR is explanatory on its own, enough to be understood as part of a changelog.
- [ ] I added or indicated the right labels.
<!-- If relevant, you can add a milestone label or indicate an ideal timeline for this PR, including whether the progress of this PR is linked to other PRs being completed before or after it. -->
- [ ] I added information regarding the timeline of completion for this PR.
<!-- If you want, you can ask for reviews on a draft PR -->
- [ ] Please, comment on my PR while it's a draft and give me feedback on the development!
